### PR TITLE
Pin node repo to avoid preferring debian's nodejs packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,6 +97,9 @@ RUN (echo "Package: *" && echo "Pin: origin deb.nodesource.com" && echo "Pin-Pri
     curl -sL https://deb.nodesource.com/setup_${NODE_VERSION}.x | sudo -E bash - && \
     sudo apt-get -q install -y -V nodejs build-essential
 
+# Install yarn and bower for convenience
+RUN npm install -g yarn bower
+
 # Install latest release of clitools (ct)
 RUN set -ex && \
     latest_url=$(curl -s https://api.github.com/repos/kitzberger/clitools/releases/latest | jq -r ".assets[].browser_download_url") && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,8 +92,9 @@ RUN set -ex \
     && echo "UsePAM yes" >> /etc/ssh/sshd_config \
     && echo "application ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
-# Install node
-RUN curl -sL https://deb.nodesource.com/setup_${NODE_VERSION}.x | sudo -E bash - && \
+# Install node (pin, so that in doubt, the debian version is never installed)
+RUN (echo "Package: *" && echo "Pin: origin deb.nodesource.com" && echo "Pin-Priority: 1000") > /etc/apt/preferences.d/nodesource && \
+    curl -sL https://deb.nodesource.com/setup_${NODE_VERSION}.x | sudo -E bash - && \
     sudo apt-get -q install -y -V nodejs build-essential
 
 # Install latest release of clitools (ct)


### PR DESCRIPTION
I.e. on newer debian versions you cannot install node 10 without this.

Also install yarn and bower for projects that might require it (still).