### PR TITLE
Clitools 2.6.0 and no more PHP 7.0

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -15,7 +15,6 @@ jobs:
           - php-version: "7.4"
           - php-version: "7.3"
           - php-version: "7.2"
-          - php-version: "7.0"
 
     steps:
       - name: "Checkout Sourcecode"

--- a/Dockerfile
+++ b/Dockerfile
@@ -115,7 +115,7 @@ RUN npm install -g yarn bower
 
 # Install latest release of clitools (ct)
 RUN set -ex && \
-    latest_url=$(curl -s https://api.github.com/repos/kitzberger/clitools/releases/latest | jq -r ".assets[].browser_download_url") && \
+    latest_url=$(curl -s https://api.github.com/repos/cron-eu/clitools/releases/latest | jq -r ".assets[].browser_download_url") && \
     curl -Lo /usr/local/bin/ct $latest_url && \
     chmod 777 /usr/local/bin/ct
 


### PR DESCRIPTION
* Upgrade to clitools 2.6.0 (See https://github.com/cron-eu/clitools/releases/tag/2.6.0)
* Do not build for PHP 7.0 anymore (clitools 2.6 only works for 7.2 and later)