### PR TITLE
Optimize PHP 7.0 images

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -99,7 +99,7 @@ jobs:
           - php-version: "7.2"
             node-version: "10"
           - php-version: "7.0"
-            node-version: "8"
+            node-version: "14"
 
     steps:
       - name: "Checkout Sourcecode"

--- a/.github/workflows/build-only.yml
+++ b/.github/workflows/build-only.yml
@@ -16,6 +16,7 @@ jobs:
           - php-version: "7.4"
           - php-version: "7.3"
           - php-version: "7.2"
+          - php-version: "7.0"
 
     steps:
       - name: "Checkout Sourcecode"
@@ -59,16 +60,12 @@ jobs:
             node-version: "16"
           - php-version: "7.4"
             node-version: "16"
-          - php-version: "7.4"
-            node-version: "14"
-          - php-version: "7.4"
-            node-version: "12"
-          - php-version: "7.4"
-            node-version: "10"
           - php-version: "7.3"
             node-version: "10"
           - php-version: "7.2"
             node-version: "10"
+          - php-version: "7.0"
+            node-version: "14"
 
     steps:
       - name: "Checkout Sourcecode"

--- a/Dockerfile
+++ b/Dockerfile
@@ -146,11 +146,13 @@ RUN (echo "Package: *" && echo "Pin: origin deb.nodesource.com" && echo "Pin-Pri
 RUN npm install -g yarn bower
 
 # Install latest release of clitools (ct)
-RUN set -ex && \
-    latest_url=$(curl -s https://api.github.com/repos/cron-eu/clitools/releases/latest | jq -r ".assets[].browser_download_url") && \
-    test "${PHP_MINOR_VERSION}" = "7.0" && latest_url=https://github.com/kitzberger/clitools/releases/download/2.5.4/clitools.phar && \
-    curl -Lo /usr/local/bin/ct $latest_url && \
+RUN <<-EOF
+    set -ex
+    latest_url=$(curl -s https://api.github.com/repos/cron-eu/clitools/releases/latest | jq -r ".assets[].browser_download_url")
+    test "${PHP_MINOR_VERSION}" = "7.0" && latest_url=https://github.com/kitzberger/clitools/releases/download/2.5.4/clitools.phar
+    curl -Lo /usr/local/bin/ct $latest_url
     chmod 777 /usr/local/bin/ct
+EOF
 
 # Also root uses bash
 RUN usermod -s /bin/bash root

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,9 @@ FROM php:${PHP_MINOR_VERSION}-fpm as php-fpm
 ARG PHP_MINOR_VERSION
 ARG PHP_PACKAGES
 
+RUN echo 'APT::Install-Recommends "false";' >> /etc/apt/apt.conf.d/phpapp-norecommends && \
+    echo 'APT::Install-Suggests "false";' >> /etc/apt/apt.conf.d/phpapp-suggests
+
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/bin/
 RUN install-php-extensions $PHP_PACKAGES
 
@@ -49,7 +52,8 @@ RUN apt-get -qq update && apt-get -q install -y \
         graphicsmagick \
         curl \
         # for causal/extractor: \
-        exiftool poppler-utils
+        exiftool poppler-utils \
+    && rm -rf /var/lib/apt/lists/*
 
 # create an app user
 RUN adduser --disabled-password --gecos "" application
@@ -96,7 +100,8 @@ RUN apt-get -qq update && apt-get -q install -y \
         patch \
         screen \
         # for causal/extractor: \
-        exiftool poppler-utils
+        exiftool poppler-utils \
+    && rm -rf /var/lib/apt/lists/*
 
 # Configure ssh daemon
 RUN set -ex \
@@ -109,7 +114,8 @@ RUN set -ex \
 # Install node (pin, so that in doubt, the debian version is never installed)
 RUN (echo "Package: *" && echo "Pin: origin deb.nodesource.com" && echo "Pin-Priority: 1000") > /etc/apt/preferences.d/nodesource && \
     curl -sL https://deb.nodesource.com/setup_${NODE_VERSION}.x | sudo -E bash - && \
-    sudo apt-get -q install -y -V nodejs build-essential
+    sudo apt-get -q install -y -V nodejs && \
+    rm -rf /var/lib/apt/lists/*
 
 # Install yarn and bower for convenience
 RUN npm install -g yarn bower

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,31 @@ RUN apt-get -qq update && apt-get -q install -y \
         exiftool poppler-utils \
     && rm -rf /var/lib/apt/lists/*
 
+# Install wkhtmltopdf (only on PHP 7.0)
+RUN <<-EOF
+    set -ex \
+    # Only need this in the PHP 7.0 package for now
+    test "${PHP_MINOR_VERSION}" != "7.0" && exit
+    apt-get -qq update && apt-get -q install -y lsb-release xfonts-base xfonts-75dpi fontconfig xvfb
+    CODENAME=$(lsb_release -c -s)
+    VERSION=0.12.6-1
+    test "$CODENAME" = "bullseye" && VERSION=0.12.6.1-2
+    PLATFORM=arm64
+    test $(uname -m) = "x86_64" && PLATFORM=amd64
+    curl -L -o wkhtmltox.deb https://github.com/wkhtmltopdf/packaging/releases/download/${VERSION}/wkhtmltox_${VERSION}.${CODENAME}_${PLATFORM}.deb
+    dpkg -i wkhtmltox.deb
+    ln -s /usr/local/bin/wkhtmltopdf /usr/bin && ln -s /usr/local/bin/wkhtmltoimage /usr/bin
+    rm -rf wkhtmltox.deb /var/lib/apt/lists/*
+EOF
+
+# Other versions:
+# https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.bullseye_amd64.deb
+# https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.bullseye_arm64.deb
+# https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.buster_amd64.deb
+# https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.buster_arm64.deb
+# https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.stretch_amd64.deb
+# https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.stretch_arm64.deb
+
 # create an app user
 RUN adduser --disabled-password --gecos "" application
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Dockerfile to build the "fpm"" and "ssh" images
 # -------------------------------------------------------------------------
 
-ARG PHP_VERSION=7.4
+ARG PHP_MINOR_VERSION=7.4
 ARG NODE_VERSION=14
 ARG PHP_PACKAGES=" \
     apcu \
@@ -35,9 +35,9 @@ ARG PHP_PACKAGES=" \
 
 # -------------------------------------------------------------------------
 
-FROM php:${PHP_VERSION}-fpm as php-fpm
+FROM php:${PHP_MINOR_VERSION}-fpm as php-fpm
 
-ARG PHP_VERSION
+ARG PHP_MINOR_VERSION
 ARG PHP_PACKAGES
 
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/bin/
@@ -74,6 +74,7 @@ CMD [ "php-fpm" ]
 FROM php-fpm as ssh
 
 ARG NODE_VERSION
+ARG PHP_MINOR_VERSION
 
 RUN apt-get -qq update && apt-get -q install -y \
         # ssh daemon (use "PAM" to allow users to login without password)
@@ -116,7 +117,7 @@ RUN npm install -g yarn bower
 # Install latest release of clitools (ct)
 RUN set -ex && \
     latest_url=$(curl -s https://api.github.com/repos/cron-eu/clitools/releases/latest | jq -r ".assets[].browser_download_url") && \
-    test "${PHP_VERSION}" = "7.0" && latest_url=https://github.com/kitzberger/clitools/releases/download/2.5.4/clitools.phar && \
+    test "${PHP_MINOR_VERSION}" = "7.0" && latest_url=https://github.com/kitzberger/clitools/releases/download/2.5.4/clitools.phar && \
     curl -Lo /usr/local/bin/ct $latest_url && \
     chmod 777 /usr/local/bin/ct
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -116,6 +116,7 @@ RUN npm install -g yarn bower
 # Install latest release of clitools (ct)
 RUN set -ex && \
     latest_url=$(curl -s https://api.github.com/repos/cron-eu/clitools/releases/latest | jq -r ".assets[].browser_download_url") && \
+    test "${PHP_VERSION}" = "7.0" && latest_url=https://github.com/kitzberger/clitools/releases/download/2.5.4/clitools.phar && \
     curl -Lo /usr/local/bin/ct $latest_url && \
     chmod 777 /usr/local/bin/ct
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ test:
 build-fpm:
 	docker buildx build $(DOCKER_CACHE) $(BUILDX_OPTIONS) \
 		--platform $(PLATFORMS) \
-		--build-arg PHP_VERSION=$(PHP_VERSION) \
+		--build-arg PHP_MINOR_VERSION=$(PHP_VERSION) \
 		--tag croneu/phpapp-fpm:php-$(PHP_VERSION) \
 		--target php-fpm \
 		.
@@ -24,7 +24,7 @@ build-fpm:
 build-ssh:
 	docker buildx build $(DOCKER_CACHE) $(BUILDX_OPTIONS) \
 		--platform $(PLATFORMS) \
-		--build-arg PHP_VERSION=$(PHP_VERSION) --build-arg NODE_VERSION=$(NODE_VERSION) \
+		--build-arg PHP_MINOR_VERSION=$(PHP_VERSION) --build-arg NODE_VERSION=$(NODE_VERSION) \
 		--tag croneu/phpapp-ssh:php-$(PHP_VERSION)-node-$(NODE_VERSION) \
 		--target ssh \
 		.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Available tags:
 * `croneu/phpapp-ssh:php-7.4-node-10`
 * `croneu/phpapp-ssh:php-7.3-node-10`
 * `croneu/phpapp-ssh:php-7.2-node-10`
-* `croneu/phpapp-ssh:php-7.0-node-8`
+* `croneu/phpapp-ssh:php-7.0-node-14`
 
 You can start a container for SSH'ing into it for development purposes with the image
 `croneu/phpapp-ssh`. It is based off the `phpapp-fpm` image (thus it contains the exact same

--- a/files/entrypoint-extras.sh
+++ b/files/entrypoint-extras.sh
@@ -24,4 +24,4 @@ if [ ! -z "${APPLICATION_GID}" ]; then
 fi
 
 test -d /app && chown application. -R /app
-test -d /home/application && chown application. -R /app
+test -d /home/application && chown application. -R /home/application

--- a/files/ssh/entrypoint.sh
+++ b/files/ssh/entrypoint.sh
@@ -72,10 +72,17 @@ host=${DB_HOST}
 port=${DB_PORT}
 user=${DB_USER}
 password=${DB_PASS}
+EOF
 
+  if ! ct --version | grep 2.5.4 >/dev/null
+  then
+    # this is not compatible with ct v2.5.x (PHP 7.0), so only add this on other versions
+    cat <<EOF >> $APP_USER_HOME/.my.cnf
 [mysql]
 database=${DB_NAME}
 EOF
+  fi
+
   chown ${APP_USER}. $APP_USER_HOME/.my.cnf
 
   # Create a .clitools.ini


### PR DESCRIPTION
* PHP 7.0 but with Node 14
* clitools 2.5.4 is the latest working with PHP 7.0
* Install wkhtmltopdf in PHP 7.0 image
* Optimize the size of the images (no "recommended" packages) - **note, this also affects all other images** (smaller size due to less useless packages being installed!)
