### PR TITLE
Fix permissions only when required and not in mounts

### DIFF
--- a/files/entrypoint-extras.sh
+++ b/files/entrypoint-extras.sh
@@ -23,5 +23,9 @@ if [ ! -z "${APPLICATION_GID}" ]; then
   groupmod -g $APPLICATION_GID application
 fi
 
-test -d /app && chown application. -R /app
-test -d /home/application && chown application. -R /home/application
+if [ ! -z "${APPLICATION_UID}" ] || [ ! -z "${APPLICATION_GID}" ]; then
+  echo "* Fixing permissions in /app"
+  test -d /app && chown application. -R /app
+  echo "* Fixing permissions in /home/application"
+  test -d /home/application && find /home/application/ -mount -not -user application -exec chown application. {} \;
+fi


### PR DESCRIPTION
This avoids long starting times in case you mount composer / npm / yarn caches inside `/home/application`.

Fixes a regressions introduced with https://github.com/cron-eu/docker-phpapp-php/pull/14/commits/c569f9457ffad79b22bd4d9f19d7886443984ec3