### PR TITLE
Removed deprecated xdebug setting (profiler_output_dir)

### DIFF
--- a/files/php.ini
+++ b/files/php.ini
@@ -42,5 +42,4 @@ xdebug.idekey = "docker"
 xdebug.cli_color = 1
 xdebug.max_nesting_level = 1000
 xdebug.client_host = 'host.docker.internal'
-xdebug.profiler_output_dir = '/tmp/debug/'
 xhprof.output_dir = '/tmp/debug/'


### PR DESCRIPTION
This starts to make warnings from Xdebug 3.2.0 and later (PHP 8.x). New setting (`xhprof.output_dir`) is already configured.