### PR TITLE
Load xdebug also on PHP 7.0

### DIFF
--- a/files/entrypoint-extras.sh
+++ b/files/entrypoint-extras.sh
@@ -11,7 +11,7 @@ if [ -z "${XDEBUG_MODE}" ] || [ "${XDEBUG_MODE}" = "off" ]; then
   rm -f /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 else
   echo "* enabling XDEBUG: $XDEBUG_MODE"
-  echo "zend_extension=xdebug" > /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+  echo "zend_extension=xdebug.so" > /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 fi
 
 if [ ! -z "${APPLICATION_UID}" ]; then


### PR DESCRIPTION
In 7.0 the .so extension was required, else:

"Failed loading /usr/local/lib/php/extensions/no-debug-non-zts-20151012/xdebug"