### PR TITLE
Readd missing tools (ImageMagick and unzip)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,11 +48,13 @@ RUN install-php-extensions $PHP_PACKAGES
 
 # Other tools
 RUN apt-get -qq update && apt-get -q install -y \
-        # for TYPO3 \
+        # for TYPO3 / Neos \
+        imagemagick \
         graphicsmagick \
         ghostscript \
         curl \
         locales-all \
+        unzip \
         # for causal/extractor: \
         exiftool poppler-utils \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
These disappeared due to https://github.com/cron-eu/docker-phpapp-php/pull/14 because they where previously only being installed because they were 'recommended' by some other packages. Make it explicit here.

* ImageMagick - still needed by some environments, i.e. our Neos sites
* unzip - used for example by composer to speed up downloading packages