### PR TITLE
Allow overriding php.ini settings with ENV PHP_INI_OVERRIDE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,7 +95,7 @@ COPY files/entrypoint*.sh /
 RUN chmod +x /*.sh
 
 # Configure PHP and PHP-FPM
-ADD files/php.ini /usr/local/etc/php/conf.d/zz-custom.ini
+ADD files/php.ini /usr/local/etc/php/conf.d/zz-01-custom.ini
 ADD files/php-fpm-www.conf /usr/local/etc/php-fpm.d/www.conf
 
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Application root is `/app`. Application runs as user `application` (uid=1000).
 | `SSH_CONFIG`                           | ssh      |             | The whole content of the `.ssh/config` file                                                                                              |
 | `SSH_KNOWN_HOSTS`                      | ssh      |             | The whole content of the `.ssh/known_hosts` file                                                                                         |
 | `ENV`                                  | ssh      |             | The name of the environment to show on the shell prompt                                                                                  |
+| `PHP_INI_OVERRIDE`                     | fpm, ssh |             | Allow overriding php.ini settings. Simply the multiline content for a php.ini here                                                       |
 
 ## Example usage
 

--- a/files/entrypoint-extras.sh
+++ b/files/entrypoint-extras.sh
@@ -29,3 +29,7 @@ if [ ! -z "${APPLICATION_UID}" ] || [ ! -z "${APPLICATION_GID}" ]; then
   echo "* Fixing permissions in /home/application"
   test -d /home/application && find /home/application/ -mount -not -user application -exec chown application. {} \;
 fi
+
+if [ ! -z "${PHP_INI_OVERRIDE}" ]; then
+  echo "${PHP_INI_OVERRIDE}" > /usr/local/etc/php/conf.d/zz-02-custom.ini
+fi


### PR DESCRIPTION
I.e.:
```
PHP_INI_OVERRIDE="
memory_limit = 128M
"
```