### PR TITLE
Do not use github API anymore for clitools download

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: "Docker build php-${{ matrix.php-version }}"
         run: |
-          make build-fpm GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
+          make build-fpm \
             PHP_VERSION=${{ matrix.php-version }} \
             DOCKER_CACHE_PATH=.buildx-cache
 
@@ -58,7 +58,7 @@ jobs:
 
       - name: "Docker push php-${{ matrix.php-version }}"
         run: |
-          make build-fpm GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
+          make build-fpm \
             PHP_VERSION=${{ matrix.php-version }} \
             DOCKER_CACHE_PATH=.buildx-cache \
             BUILDX_OPTIONS=--push
@@ -129,7 +129,7 @@ jobs:
 
       - name: "Docker build php-${{ matrix.php-version }} node-${{ matrix.node-version }}"
         run: |
-          make build-ssh GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
+          make build-ssh \
             PHP_VERSION=${{ matrix.php-version }} NODE_VERSION=${{ matrix.node-version }} \
             DOCKER_CACHE_PATH=.buildx-cache
 
@@ -141,7 +141,7 @@ jobs:
 
       - name: "Docker push php-${{ matrix.php-version }} node-${{ matrix.node-version }}"
         run: |
-          make build-ssh GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
+          make build-ssh \
             PHP_VERSION=${{ matrix.php-version }} NODE_VERSION=${{ matrix.node-version }} \
             DOCKER_CACHE_PATH=.buildx-cache \
             BUILDX_OPTIONS=--push

--- a/.github/workflows/build-only.yml
+++ b/.github/workflows/build-only.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: "Docker build php-${{ matrix.php-version }}"
         run: |
-          make build-fpm GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
+          make build-fpm \
             PHP_VERSION=${{ matrix.php-version }} \
             PLATFORMS=linux/amd64 DOCKER_CACHE_PATH=.buildx-cache
 
@@ -84,5 +84,6 @@ jobs:
 
       - name: "Docker build php-${{ matrix.php-version }} node-${{ matrix.node-version }}"
         run: |
-          make build-ssh GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} PHP_VERSION=${{ matrix.php-version }} NODE_VERSION=${{ matrix.node-version }} \
+          make build-ssh \
+            PHP_VERSION=${{ matrix.php-version }} NODE_VERSION=${{ matrix.node-version }} \
             PLATFORMS=linux/amd64 DOCKER_CACHE_PATH=.buildx-cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,6 @@ FROM php:${PHP_MINOR_VERSION}-fpm as php-fpm
 
 ARG PHP_MINOR_VERSION
 ARG PHP_PACKAGES
-ARG GITHUB_TOKEN
 
 RUN echo 'APT::Install-Recommends "false";' >> /etc/apt/apt.conf.d/phpapp-norecommends && \
     echo 'APT::Install-Suggests "false";' >> /etc/apt/apt.conf.d/phpapp-suggests
@@ -109,7 +108,6 @@ FROM php-fpm as ssh
 
 ARG NODE_VERSION
 ARG PHP_MINOR_VERSION
-ARG GITHUB_TOKEN
 
 RUN apt-get -qq update && apt-get -q install -y \
         # ssh daemon (use "PAM" to allow users to login without password)
@@ -154,12 +152,7 @@ RUN npm install -g yarn bower
 # Install latest release of clitools (ct)
 RUN <<-EOF
     set -ex
-    GITHUB_AUTH=""
-    if [ ! -z "$GITHUB_TOKEN" ]; then
-      GITHUB_AUTH="--header 'authorization: Bearer "$GITHUB_TOKEN"'"
-    fi
-    echo "Getting latest release from: curl $GITHUB_AUTH -s https://api.github.com/repos/cron-eu/clitools/releases/latest"
-    latest_url=$(curl $GITHUB_AUTH -s https://api.github.com/repos/cron-eu/clitools/releases/latest | jq -r ".assets[].browser_download_url")
+    latest_url=https://github.com/cron-eu/clitools/releases/download/2.6.0/clitools.phar
     test "${PHP_MINOR_VERSION}" = "7.0" && latest_url=https://github.com/kitzberger/clitools/releases/download/2.5.4/clitools.phar
     curl -Lo /usr/local/bin/ct $latest_url
     chmod 777 /usr/local/bin/ct

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,6 @@ build-fpm:
 	docker buildx build $(DOCKER_CACHE) $(BUILDX_OPTIONS) \
 		--platform $(PLATFORMS) \
 		--build-arg PHP_MINOR_VERSION=$(PHP_VERSION) \
-		--build-arg GITHUB_TOKEN=$(GITHUB_TOKEN) \
 		--tag croneu/phpapp-fpm:php-$(PHP_VERSION) \
 		--target php-fpm \
 		.
@@ -26,7 +25,6 @@ build-ssh:
 	docker buildx build $(DOCKER_CACHE) $(BUILDX_OPTIONS) \
 		--platform $(PLATFORMS) \
 		--build-arg PHP_MINOR_VERSION=$(PHP_VERSION) --build-arg NODE_VERSION=$(NODE_VERSION) \
-		--build-arg GITHUB_TOKEN=$(GITHUB_TOKEN) \
 		--tag croneu/phpapp-ssh:php-$(PHP_VERSION)-node-$(NODE_VERSION) \
 		--target ssh \
 		.


### PR DESCRIPTION
Instead hardcode the versions to download from clitools:
- 2.6.0 for PHP >7.1
- 2.5.4 for PHP 7.0

Using GITHUB_TOKEN turned out to be not so easy and for this simple task it was just not worth the effort (took too much time already researching it, worked on the PR, and at the end it didn't work after merging...).