### PR TITLE
Enable PDF/PS processing by ImageMagick again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,9 @@ RUN <<-EOF
     rm -rf wkhtmltox.deb /var/lib/apt/lists/*
 EOF
 
+# Enable PDF/PS processing by ImageMagick again (disabled in distributions)
+RUN perl -i -ne 'print if ! /rights="none".*"(PDF|PS.?|EPS|XPS)"/' /etc/ImageMagick-*/policy.xml
+
 # Other versions:
 # https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.bullseye_amd64.deb
 # https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.bullseye_arm64.deb


### PR DESCRIPTION
This has been disabled in distributions due to security concerns (see https://www.kb.cert.org/vuls/id/332928/)

Error is:

```
identify-im6.q16: attempt to perform an operation not allowed by the security policy `PDF' @ error/constitute.c/IsCoderAuthorized/421.
```
