### PR TITLE
Add healthchecks for php-fpm and php-ssh containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,6 +102,12 @@ RUN perl -i -ne 'print if ! /rights="none".*"(PDF|PS.?|EPS|XPS)"/' /etc/ImageMag
 # https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.stretch_amd64.deb
 # https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.stretch_arm64.deb
 
+# Install php-fpm healthcheck
+ADD https://raw.githubusercontent.com/renatomefi/php-fpm-healthcheck/master/php-fpm-healthcheck /usr/local/bin/php-fpm-healthcheck
+RUN chmod +x /usr/local/bin/php-fpm-healthcheck
+
+HEALTHCHECK --interval=5s --timeout=1s CMD php-fpm-healthcheck || exit 1
+
 # create an app user
 RUN adduser --disabled-password --gecos "" application
 
@@ -181,6 +187,9 @@ RUN usermod -s /bin/bash root
 
 # Install composer
 RUN curl --silent --show-error https://getcomposer.org/installer | php && mv composer.phar /usr/local/bin/composer
+
+# Enable HEALTHCHECK for SSH container
+HEALTHCHECK --interval=5s --timeout=1s CMD pgrep sshd > /dev/null || exit 1
 
 RUN usermod -s /bin/bash application
 

--- a/files/php-fpm-www.conf
+++ b/files/php-fpm-www.conf
@@ -7,3 +7,4 @@ pm.max_children = 5
 pm.start_servers = 2
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
+pm.status_path = /status

--- a/files/ssh/entrypoint.sh
+++ b/files/ssh/entrypoint.sh
@@ -6,14 +6,14 @@ set -e
 # If arguments have been passed, we want to "run" them instead of starting the SSH daemon
 # Also do not do any time consuming actions (network activity)
 
-IS_RUN=0
-test $# -ge 1 && IS_RUN=1
+IS_RUN="false"
+test $# -ge 1 && IS_RUN="true"
 
 # User running the application
 APP_USER=application
 APP_USER_HOME=$(eval echo "~${APP_USER}")
 
-if [[ ! $IS_RUN ]]; then
+if [[ "$IS_RUN" == "false" ]]; then
   echo "* Activating 'application' user and SSH keys"
 
   # Unlock 'application' account
@@ -24,7 +24,7 @@ fi
 # Make sure 'application' home directory exists...
 mkdir -p $APP_USER_HOME && chown $APP_USER $APP_USER_HOME
 
-if [[ ! $IS_RUN ]] && [[ -z "${IMPORT_GITLAB_PUB_KEYS}" ]] && [[ -z "${IMPORT_GITHUB_PUB_KEYS}" ]]; then
+if [[ "$IS_RUN" == "false" ]] && [[ -z "${IMPORT_GITLAB_PUB_KEYS}" ]] && [[ -z "${IMPORT_GITHUB_PUB_KEYS}" ]]; then
   echo "WARNING: env variable \$IMPORT_GITHUB_PUB_KEYS or IMPORT_GITLAB_PUB_KEYS is not set. Please set it to have access to this container via SSH."
 fi
 
@@ -41,7 +41,7 @@ fi
 # -------------------------------------------------------------------------
 # Import SSH keys from Gitlab
 
-if [[ ! -z "${IMPORT_GITLAB_PUB_KEYS}" && ! $IS_RUN ]] ; then
+if [[ ! -z "${IMPORT_GITLAB_PUB_KEYS}" && "$IS_RUN" == "false" ]] ; then
   # Read passed to container ENV IMPORT_GITLAB_PUB_KEYS variable with coma-separated
   # user list and add public key(s) for these users to authorized_keys on 'application' account.
   for user in $(echo $IMPORT_GITLAB_PUB_KEYS | tr "," "\n"); do
@@ -53,7 +53,7 @@ fi
 # -------------------------------------------------------------------------
 # Import SSH keys from Github
 
-if [[ ! -z "${IMPORT_GITHUB_PUB_KEYS}" && ! $IS_RUN ]]; then
+if [[ ! -z "${IMPORT_GITHUB_PUB_KEYS}" && "$IS_RUN" == "false" ]]; then
   # Read passed to container ENV IMPORT_GITHUB_PUB_KEYS variable with coma-separated
   # user list and add public key(s) for these users to authorized_keys on 'application' account.
   for user in $(echo $IMPORT_GITHUB_PUB_KEYS | tr "," "\n"); do
@@ -127,7 +127,7 @@ source /entrypoint-extras.sh
 # -------------------------------------------------------------------------
 # Start the real entrypoint
 
-if [[ $IS_RUN ]]; then
+if [[ "$IS_RUN" == "true" ]]; then
   # with arguments, start the command passed to me
   test -d /app && cd /app
   exec gosu "$APP_USER" "$@"


### PR DESCRIPTION
This allows to use `docker compose up -d --wait` to make sure they are really started.

* PHP-FPM is checked via https://github.com/renatomefi/php-fpm-healthcheck
* SSH is checked simply if the `sshd` process is running