### PR TITLE
Also do not install "recommends" in "ssh" image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -135,7 +135,7 @@ FROM php-fpm as ssh
 ARG NODE_VERSION
 ARG PHP_MINOR_VERSION
 
-# Do not installed "recommends" or "suggests" packages, less garbage
+# Do not install "recommends" or "suggests" packages, less garbage
 RUN echo 'APT::Install-Recommends "0";' >> /etc/apt/apt.conf.d/phpapp-norecommends && \
     echo 'APT::Install-Suggests "0";' >> /etc/apt/apt.conf.d/phpapp-suggests
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,8 @@ FROM php:${PHP_MINOR_VERSION}-fpm as php-fpm
 ARG PHP_MINOR_VERSION
 ARG PHP_PACKAGES
 
-RUN echo 'APT::Install-Recommends "false";' >> /etc/apt/apt.conf.d/phpapp-norecommends && \
-    echo 'APT::Install-Suggests "false";' >> /etc/apt/apt.conf.d/phpapp-suggests
+RUN echo 'APT::Install-Recommends "0";' >> /etc/apt/apt.conf.d/phpapp-norecommends && \
+    echo 'APT::Install-Suggests "0";' >> /etc/apt/apt.conf.d/phpapp-suggests
 
 RUN <<EOF
 	if grep '^VERSION_ID="9"' /etc/os-release >/dev/null ; then
@@ -135,9 +135,23 @@ FROM php-fpm as ssh
 ARG NODE_VERSION
 ARG PHP_MINOR_VERSION
 
+# Do not installed "recommends" or "suggests" packages, less garbage
+RUN echo 'APT::Install-Recommends "0";' >> /etc/apt/apt.conf.d/phpapp-norecommends && \
+    echo 'APT::Install-Suggests "0";' >> /etc/apt/apt.conf.d/phpapp-suggests
+
+# Install all tools we need in our standard PHP cli
 RUN apt-get -qq update && apt-get -q install -y \
         # ssh daemon (use "PAM" to allow users to login without password)
         openssh-server sudo gosu \
+        # for TYPO3 / Neos \
+        imagemagick \
+        graphicsmagick \
+        ghostscript \
+        curl \
+        locales-all \
+        unzip \
+        # for causal/extractor: \
+        exiftool poppler-utils \
         # for composer:
         git zip make \
         # other tools for CLI pleasure:


### PR DESCRIPTION
The ssh image is also currently "bloated" with debian packages which are installed due to "Recommends" or "Suggests". Remove these, but keep packages that we really want and need.

This is kind of a follow-up to https://github.com/cron-eu/docker-phpapp-php/pull/14 - which only affected the FPM images.

The following packages are thus no longer installed in the ssh image:

```
dbus-bin
dbus-daemon
dbus-session-bus-common
dbus-system-bus-common
dbus-user-session
dbus
dmsetup
fontconfig
fonts-droid-fallback
fonts-noto-mono
gsfonts
libapparmor1
libarchive-zip-perl
libcryptsetup12
libdatrie1
libdbd-mariadb-perl
libdbi-perl
libdevmapper1.02.1
libdjvulibre-text
libdjvulibre21
libfdisk1
libfribidi0
libglib2.0-data
libgraphite2-3
libharfbuzz0b
libimagequant0
libimath-3-1-29
libip4tc2
libjson-c5
libjxr-tools
libjxr0
libkmod2
libmagickcore-6.q16-6-extra
libmime-charset-perl
libnetpbm11
libnss-systemd
libopenexr-3-1-30
libpam-cap
libpam-systemd
libpango-1.0-0
libpangocairo-1.0-0
libpangoft2-1.0-0
libpaper-utils
libraqm0
libsombok3
libsystemd-shared
libterm-readkey-perl
libthai-data
libthai0
libunicode-linebreak-perl
libxmuu1
mailcap
mime-support
ncurses-term
netpbm
psmisc
psutils
python3-olefile
python3-pil
python3-pkg-resources
python3-pygments
shared-mime-info
systemd-sysv
systemd-timesyncd
systemd
xauth
xdg-user-dirs
xxd
```
