### PR TITLE
Fix deprecated syntax in chown

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -215,6 +215,6 @@ COPY files/ssh/ /
 RUN rm -f /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 COPY files/entrypoint-extras.sh /
 
-RUN chmod +x /*.sh && chown -R application. /home/application
+RUN chmod +x /*.sh && chown -R application: /home/application
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/files/entrypoint-extras.sh
+++ b/files/entrypoint-extras.sh
@@ -25,9 +25,9 @@ fi
 
 if [ ! -z "${APPLICATION_UID}" ] || [ ! -z "${APPLICATION_GID}" ]; then
   echo "* Fixing permissions in /app"
-  test -d /app && chown application. -R /app
+  test -d /app && chown application: -R /app
   echo "* Fixing permissions in /home/application"
-  test -d /home/application && find /home/application/ -mount -not -user application -exec chown application. {} \;
+  test -d /home/application && find /home/application/ -mount -not -user application -exec chown application: {} \;
 fi
 
 if [ ! -z "${PHP_INI_OVERRIDE}" ]; then

--- a/files/ssh/entrypoint.sh
+++ b/files/ssh/entrypoint.sh
@@ -101,7 +101,7 @@ database=${DB_NAME}
 EOF
   fi
 
-  chown ${APP_USER}. $APP_USER_HOME/.my.cnf
+  chown ${APP_USER}: $APP_USER_HOME/.my.cnf
 
   # Create a .clitools.ini
   cat <<EOF > $APP_USER_HOME/.clitools.ini
@@ -117,7 +117,7 @@ fi
 
 # -------------------------------------------------------------------------
 # Make sure the /app directory is writeable by the user
-test -d /app && chown ${APP_USER}. /app
+test -d /app && chown ${APP_USER}: /app
 
 # -------------------------------------------------------------------------
 # Extra PHP initialization


### PR DESCRIPTION
Avoid deprecation warning when starting a container:
```
  chown: warning: '.' should be ':': 'application.'
```

This happens since Debian Bookworm, which updated coreutils to 9.1.