### PR TITLE
Allow multiline PHP_INI_OVERRIDE with "\n"

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Application root is `/app`. Application runs as user `application` (uid=1000).
 | `SSH_KNOWN_HOSTS`                      | ssh      |             | The whole content of the `.ssh/known_hosts` file                                                                                         |
 | `SSH_PRIVATE_KEY`                      | ssh      |             | A SSH private key to load in an `ssh-agent`, useful if you run a SSH container with commands                                             |                                                    |
 | `ENV`                                  | ssh      |             | The name of the environment to show on the shell prompt                                                                                  |
-| `PHP_INI_OVERRIDE`                     | fpm, ssh |             | Allow overriding php.ini settings. Simply the multiline content for a php.ini here                                                       |
+| `PHP_INI_OVERRIDE`                     | fpm, ssh |             | Allow overriding php.ini settings. Simply the multiline content for a php.ini here. Use "\n" for multiline i.e. in ECS                   |
 
 ## Example usage
 

--- a/files/entrypoint-extras.sh
+++ b/files/entrypoint-extras.sh
@@ -31,5 +31,5 @@ if [ ! -z "${APPLICATION_UID}" ] || [ ! -z "${APPLICATION_GID}" ]; then
 fi
 
 if [ ! -z "${PHP_INI_OVERRIDE}" ]; then
-  echo "${PHP_INI_OVERRIDE}" > /usr/local/etc/php/conf.d/zz-02-custom.ini
+  echo "${PHP_INI_OVERRIDE}" | sed -e 's/\\n/\n/g' > /usr/local/etc/php/conf.d/zz-02-custom.ini
 fi


### PR DESCRIPTION
In ECS its not possible to use multiline environment variables, so allow using the string "\n" to create multiline file in one line