### PR TITLE
Allow customization of FPM settings via PHP_FPM_OVERRIDE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -122,7 +122,6 @@ RUN chmod +x /*.sh
 
 # Configure PHP and PHP-FPM
 ADD files/php.ini /usr/local/etc/php/conf.d/zz-01-custom.ini
-ADD files/php-fpm-www.conf /usr/local/etc/php-fpm.d/www.conf
 
 ENTRYPOINT [ "/entrypoint.sh" ]
 # Override CMD too (see https://github.com/moby/moby/issues/5147)

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Application root is `/app`. Application runs as user `application` (uid=1000).
 | `SSH_PRIVATE_KEY`                      | ssh      |             | A SSH private key to load in an `ssh-agent`, useful if you run a SSH container with commands                                             |                                                    |
 | `ENV`                                  | ssh      |             | The name of the environment to show on the shell prompt                                                                                  |
 | `PHP_INI_OVERRIDE`                     | fpm, ssh |             | Allow overriding php.ini settings. Simply the multiline content for a php.ini here. Use "\n" for multiline i.e. in ECS                   |
+| `PHP_FPM_OVERRIDE`                     | fpm      |             | Allow overriding php-fpm pool settings. The multiline content for php-fpm.conf here. Use "\n" for multiline i.e. in ECS                  |
 
 ## Example usage
 

--- a/example-app/docker-compose.yml
+++ b/example-app/docker-compose.yml
@@ -19,7 +19,7 @@ services:
           - example-app.vm
 
   php:
-    image: croneu/phpapp-fpm:php-7.4
+    image: croneu/phpapp-fpm:php-8.1
     env_file:
       - '.env.docker'
       - '.env'
@@ -27,7 +27,7 @@ services:
       - app:/app
 
   ssh:
-    image: croneu/phpapp-ssh:php-7.4-node-16
+    image: croneu/phpapp-ssh:php-8.1-node-16
     ports:
       - '1122:22'
     volumes:

--- a/files/entrypoint.sh
+++ b/files/entrypoint.sh
@@ -5,5 +5,32 @@
 # Override some PHP settings
 . /entrypoint-extras.sh
 
+PHP_FPM_POOL_CONF=/usr/local/etc/php-fpm.d/www.conf
+
+# Configure FPM, first the defaults:
+cat <<EOF > $PHP_FPM_POOL_CONF
+[www]
+user = application
+group = application
+listen = 127.0.0.1:9000
+pm = dynamic
+pm.max_children = 5
+pm.start_servers = 2
+pm.min_spare_servers = 1
+pm.max_spare_servers = 3
+pm.status_path = /status
+EOF
+
+# Allow overriding this with settings coming from PHP_FPM_OVERRIDE
+if [ ! -z "${PHP_FPM_OVERRIDE}" ]; then
+  echo "* Customizing FPM with PHP_FPM_OVERRIDE:"
+  echo "- - - 8< - - -"
+  echo "${PHP_FPM_OVERRIDE}" | sed -e 's/\\n/\n/g'
+  echo "- - - 8< - - -"
+  echo "# Customizations from PHP_FPM_OVERRIDE:" >> $PHP_FPM_POOL_CONF
+  echo "${PHP_FPM_OVERRIDE}" | sed -e 's/\\n/\n/g' >> $PHP_FPM_POOL_CONF
+fi
+
+
 # Start the "real" entrypoint
 . /usr/local/bin/docker-php-entrypoint


### PR DESCRIPTION
Use `PHP_FPM_OVERRIDE` to override the default php-fpm.conf settings (see https://www.php.net/manual/en/install.fpm.configuration.php).

Default is:

```
user = application
group = application
listen = 127.0.0.1:9000
pm = dynamic
pm.max_children = 5
pm.start_servers = 2
pm.min_spare_servers = 1
pm.max_spare_servers = 3
pm.status_path = /status
```

Override for example like this:

```
PHP_FPM_OVERRIDE="
slowlog = /tmp/slow.log
request_slowlog_timeout = 3s
pm.max_children = 15
"
```

Or if your system doesn't support multiline ENV (i.e. ECS):

```
PHP_FPM_OVERRIDE="slowlog = /tmp/slow.log\nrequest_slowlog_timeout = 3s\npm.max_children = 15"
```