### PR TITLE
Fix bug in PHP_FPM_OVERRIDE

### DIFF
--- a/example-app/.env.example
+++ b/example-app/.env.example
@@ -20,3 +20,19 @@ DB_HOST=mysql
 DB_USER=dev
 DB_PASS=dev
 DB_NAME=typo3
+
+# -----------------------------------------
+# PHP settings overrides (examples)
+# -----------------------------------------
+
+PHP_INI_OVERRIDE="
+upload_max_filesize = 256M
+post_max_size = 256M
+memory_limit = 3G
+"
+
+PHP_FPM_OVERRIDE="
+slowlog = /tmp/slow.log
+request_slowlog_timeout = 3s
+pm.max_children = 5
+"

--- a/files/entrypoint.sh
+++ b/files/entrypoint.sh
@@ -27,10 +27,9 @@ if [ ! -z "${PHP_FPM_OVERRIDE}" ]; then
   echo "- - - 8< - - -"
   echo "${PHP_FPM_OVERRIDE}" | sed -e 's/\\n/\n/g'
   echo "- - - 8< - - -"
-  echo "# Customizations from PHP_FPM_OVERRIDE:" >> $PHP_FPM_POOL_CONF
+  echo "; Customizations from PHP_FPM_OVERRIDE:" >> $PHP_FPM_POOL_CONF
   echo "${PHP_FPM_OVERRIDE}" | sed -e 's/\\n/\n/g' >> $PHP_FPM_POOL_CONF
 fi
-
 
 # Start the "real" entrypoint
 . /usr/local/bin/docker-php-entrypoint


### PR DESCRIPTION
Use correct comment sign for the .conf file (`;` and not `#`). Error when starting is:
```
example-app-php-1  | [17-Aug-2023 14:10:01] ERROR: [/usr/local/etc/php-fpm.d/www.conf:13] value is NULL for a ZEND_INI_PARSER_ENTRY
example-app-php-1  | [17-Aug-2023 14:10:01] ERROR: Unable to include /usr/local/etc/php-fpm.d/www.conf from /usr/local/etc/php-fpm.conf at line 13
example-app-php-1  | [17-Aug-2023 14:10:01] ERROR: failed to load configuration file '/usr/local/etc/php-fpm.conf'
example-app-php-1  | [17-Aug-2023 14:10:01] ERROR: FPM initialization failed
```
