### PR TITLE
GitHub actions update, Deprecate PHP 7.0, 7.2, 7.3

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -19,9 +19,6 @@ jobs:
           - php-version: "8.2"
           - php-version: "8.1"
           - php-version: "7.4"
-          - php-version: "7.3"
-          - php-version: "7.2"
-          - php-version: "7.0"
 
     steps:
       - name: "Checkout Sourcecode"
@@ -86,12 +83,6 @@ jobs:
             node-version: "12"
           - php-version: "7.4"
             node-version: "10"
-          - php-version: "7.3"
-            node-version: "10"
-          - php-version: "7.2"
-            node-version: "10"
-          - php-version: "7.0"
-            node-version: "14"
 
     steps:
       - name: "Checkout Sourcecode"

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - master
 
+env:
+  PLATFORMS: linux/arm64/v8,linux/amd64
+
 jobs:
   build_fpm:
     runs-on: ubuntu-latest
@@ -36,40 +39,23 @@ jobs:
           endpoint: "ssh://ec2-user@arm.d.cron.eu"
           ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }}
 
-      - name: "Cache Docker layers"
-        uses: actions/cache@v3
-        with:
-          path: .buildx-cache
-          key: buildx-${{ matrix.php-version }}-${{ github.sha }}
-          restore-keys: |
-            buildx-${{ matrix.php-version }}-${{ github.sha }}
-            buildx-${{ matrix.php-version }}
-            buildx
-
-      - name: "Docker build php-${{ matrix.php-version }}"
-        run: |
-          make build-fpm \
-            PHP_VERSION=${{ matrix.php-version }} \
-            DOCKER_CACHE_PATH=.buildx-cache
-
       - name: "Login to DockerHub"
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: "Docker push php-${{ matrix.php-version }}"
-        run: |
-          make build-fpm \
-            PHP_VERSION=${{ matrix.php-version }} \
-            DOCKER_CACHE_PATH=.buildx-cache \
-            BUILDX_OPTIONS=--push
-
-      - name: "Upload artefacts for our next job to use"
-        uses: actions/upload-artifact@v3
+      - name: "Docker build and push (fpm image)"
+        uses: docker/build-push-action@v4
         with:
-          name: buildx-${{ matrix.php-version }}-${{ github.sha }}
-          path: .buildx-cache
+          tags: "croneu/phpapp-fpm:php-${{ matrix.php-version }}"
+          platforms: ${{ env.PLATFORMS }}
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          target: php-fpm
+          build-args: |
+            PHP_MINOR_VERSION=${{ matrix.php-version }}
 
       - name: "Update Docker Hub Description (croneu/phpapp-fpm)"
         uses: peter-evans/dockerhub-description@v3
@@ -123,30 +109,24 @@ jobs:
           endpoint: "ssh://ec2-user@arm.d.cron.eu"
           ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }}
 
-      - name: "Download already created docker layers"
-        uses: actions/download-artifact@v2
-        with:
-          name: buildx-${{ matrix.php-version }}-${{ github.sha }}
-          path: .buildx-cache
-
-      - name: "Docker build php-${{ matrix.php-version }} node-${{ matrix.node-version }}"
-        run: |
-          make build-ssh \
-            PHP_VERSION=${{ matrix.php-version }} NODE_VERSION=${{ matrix.node-version }} \
-            DOCKER_CACHE_PATH=.buildx-cache
-
       - name: "Login to DockerHub"
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: "Docker push php-${{ matrix.php-version }} node-${{ matrix.node-version }}"
-        run: |
-          make build-ssh \
-            PHP_VERSION=${{ matrix.php-version }} NODE_VERSION=${{ matrix.node-version }} \
-            DOCKER_CACHE_PATH=.buildx-cache \
-            BUILDX_OPTIONS=--push
+      - name: "Docker build and push (ssh image)"
+        uses: docker/build-push-action@v4
+        with:
+          tags: "croneu/phpapp-ssh:php-${{ matrix.php-version }}-node-${{ matrix.node-version }}"
+          platforms: ${{ env.PLATFORMS }}
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          target: ssh
+          build-args: |
+            PHP_MINOR_VERSION=${{ matrix.php-version }}
+            NODE_VERSION=${{ matrix.node-version }}
 
       - name: "Update Docker Hub Description (croneu/phpapp-ssh)"
         uses: peter-evans/dockerhub-description@v3

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -22,11 +22,11 @@ jobs:
 
     steps:
       - name: "Checkout Sourcecode"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: "Set up Docker Buildx"
         id: builder
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: "Append ARM buildx builder from AWS"
         uses: baschny/append-buildx-action@v1
@@ -37,7 +37,7 @@ jobs:
           ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: "Cache Docker layers"
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .buildx-cache
           key: buildx-${{ matrix.php-version }}-${{ github.sha }}
@@ -53,7 +53,7 @@ jobs:
             DOCKER_CACHE_PATH=.buildx-cache
 
       - name: "Login to DockerHub"
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -66,18 +66,16 @@ jobs:
             BUILDX_OPTIONS=--push
 
       - name: "Upload artefacts for our next job to use"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: buildx-${{ matrix.php-version }}-${{ github.sha }}
           path: .buildx-cache
 
       - name: "Update Docker Hub Description (croneu/phpapp-fpm)"
-        uses: peter-evans/dockerhub-description@v2
+        uses: peter-evans/dockerhub-description@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
-          # Note: the "TOKEN" does not work for the docker hub API yet, see
-          # https://github.com/peter-evans/dockerhub-description/issues/10
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
           repository: croneu/phpapp-fpm
           short-description: ${{ github.event.repository.description }} - PHP-FPM
 
@@ -111,11 +109,11 @@ jobs:
 
     steps:
       - name: "Checkout Sourcecode"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: "Set up Docker Buildx"
         id: builder
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: "Append ARM buildx builder from AWS"
         uses: baschny/append-buildx-action@v1
@@ -138,7 +136,7 @@ jobs:
             DOCKER_CACHE_PATH=.buildx-cache
 
       - name: "Login to DockerHub"
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -151,11 +149,9 @@ jobs:
             BUILDX_OPTIONS=--push
 
       - name: "Update Docker Hub Description (croneu/phpapp-ssh)"
-        uses: peter-evans/dockerhub-description@v2
+        uses: peter-evans/dockerhub-description@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
-          # Note: the "TOKEN" does not work for the docker hub API yet, see
-          # https://github.com/peter-evans/dockerhub-description/issues/10
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
           repository: croneu/phpapp-ssh
           short-description: ${{ github.event.repository.description }} - SSH

--- a/.github/workflows/build-only.yml
+++ b/.github/workflows/build-only.yml
@@ -65,7 +65,7 @@ jobs:
         id: builder
         uses: docker/setup-buildx-action@v2
 
-      - name: "Docker build and push (ssh image)"
+      - name: "Docker build only (ssh image)"
         uses: docker/build-push-action@v4
         with:
           tags: "croneu/phpapp-ssh:php-${{ matrix.php-version }}-node-${{ matrix.node-version }}"

--- a/.github/workflows/build-only.yml
+++ b/.github/workflows/build-only.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - master
 
+env:
+  # we only test if a build passes on amd64 (faster)
+  PLATFORMS: linux/amd64
+
 jobs:
   build_fpm:
     runs-on: ubuntu-latest
@@ -28,27 +32,17 @@ jobs:
         id: builder
         uses: docker/setup-buildx-action@v2
 
-      - name: "Cache Docker layers"
-        uses: actions/cache@v3
+      - name: "Docker build only (fpm image)"
+        uses: docker/build-push-action@v4
         with:
-          path: .buildx-cache
-          key: buildx-${{ matrix.php-version }}-${{ github.sha }}
-          restore-keys: |
-            buildx-${{ matrix.php-version }}-${{ github.sha }}
-            buildx-${{ matrix.php-version }}
-            buildx
-
-      - name: "Docker build php-${{ matrix.php-version }}"
-        run: |
-          make build-fpm \
-            PHP_VERSION=${{ matrix.php-version }} \
-            PLATFORMS=linux/amd64 DOCKER_CACHE_PATH=.buildx-cache
-
-      - name: "Upload artefacts for our next job to use"
-        uses: actions/upload-artifact@v3
-        with:
-          name: buildx-${{ matrix.php-version }}-${{ github.sha }}
-          path: .buildx-cache
+          tags: "croneu/phpapp-fpm:php-${{ matrix.php-version }}"
+          platforms: ${{ env.PLATFORMS }}
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          target: php-fpm
+          build-args: |
+            PHP_MINOR_VERSION=${{ matrix.php-version }}
 
   build_ssh:
     needs:
@@ -80,14 +74,15 @@ jobs:
         id: builder
         uses: docker/setup-buildx-action@v2
 
-      - name: "Download already created docker layers"
-        uses: actions/download-artifact@v2
+      - name: "Docker build and push (ssh image)"
+        uses: docker/build-push-action@v4
         with:
-          name: buildx-${{ matrix.php-version }}-${{ github.sha }}
-          path: .buildx-cache
-
-      - name: "Docker build php-${{ matrix.php-version }} node-${{ matrix.node-version }}"
-        run: |
-          make build-ssh \
-            PHP_VERSION=${{ matrix.php-version }} NODE_VERSION=${{ matrix.node-version }} \
-            PLATFORMS=linux/amd64 DOCKER_CACHE_PATH=.buildx-cache
+          tags: "croneu/phpapp-ssh:php-${{ matrix.php-version }}-node-${{ matrix.node-version }}"
+          platforms: ${{ env.PLATFORMS }}
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          target: ssh
+          build-args: |
+            PHP_MINOR_VERSION=${{ matrix.php-version }}
+            NODE_VERSION=${{ matrix.node-version }}

--- a/.github/workflows/build-only.yml
+++ b/.github/workflows/build-only.yml
@@ -20,9 +20,6 @@ jobs:
           - php-version: "8.2"
           - php-version: "8.1"
           - php-version: "7.4"
-          - php-version: "7.3"
-          - php-version: "7.2"
-          - php-version: "7.0"
 
     steps:
       - name: "Checkout Sourcecode"
@@ -59,12 +56,6 @@ jobs:
             node-version: "16"
           - php-version: "7.4"
             node-version: "16"
-          - php-version: "7.3"
-            node-version: "10"
-          - php-version: "7.2"
-            node-version: "10"
-          - php-version: "7.0"
-            node-version: "14"
 
     steps:
       - name: "Checkout Sourcecode"

--- a/.github/workflows/build-only.yml
+++ b/.github/workflows/build-only.yml
@@ -22,14 +22,14 @@ jobs:
 
     steps:
       - name: "Checkout Sourcecode"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: "Set up Docker Buildx"
         id: builder
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: "Cache Docker layers"
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .buildx-cache
           key: buildx-${{ matrix.php-version }}-${{ github.sha }}
@@ -45,7 +45,7 @@ jobs:
             PLATFORMS=linux/amd64 DOCKER_CACHE_PATH=.buildx-cache
 
       - name: "Upload artefacts for our next job to use"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: buildx-${{ matrix.php-version }}-${{ github.sha }}
           path: .buildx-cache
@@ -74,11 +74,11 @@ jobs:
 
     steps:
       - name: "Checkout Sourcecode"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: "Set up Docker Buildx"
         id: builder
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: "Download already created docker layers"
         uses: actions/download-artifact@v2

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,16 @@
 
-PLATFORMS=linux/arm64/v8,linux/amd64
+# For local testing
+
+PLATFORMS=linux/amd64
+#PLATFORMS=linux/arm64/v8
 
 # Defaults:
-PHP_VERSION=7.4
-NODE_VERSION=14
+PHP_VERSION=8.1
+NODE_VERSION=16
 
-#BUILDX_OPTIONS=--push
+BUILDX_OPTIONS=--load
 DOCKER_CACHE_PATH=.buildx-cache
 DOCKER_CACHE=--cache-from "type=local,src=$(DOCKER_CACHE_PATH)" --cache-to "type=local,mode=max,dest=$(DOCKER_CACHE_PATH)"
-
-test:
-	echo DOCKER_CACHE_PATH: $(DOCKER_CACHE_PATH)
-	echo DOCKER_CACHE: $(DOCKER_CACHE)
 
 build-fpm:
 	docker buildx build $(DOCKER_CACHE) $(BUILDX_OPTIONS) \

--- a/README.md
+++ b/README.md
@@ -4,15 +4,17 @@
 
 Part of the `docker-phpapp` image suite.
 
-Opinionated docker images for running PHP-Applications used at cron IT GmbH - mostly
-for TYPO3 projects.
+Opinionated docker images for running PHP-Applications used at cron IT GmbH -
+mostly for TYPO3 and Neos projects but generic for any PHP application.
 
 Images for **amd64** and **arm64** (i.e. they also run on Apple M1).
 
 Born out of the desire to have good (and simple) multiplatform images for our developers
-to work on our PHP projects (also on M1 / ARM machines), mainly on TYPO3 projects.
+to work on our PHP projects (also on M1 / ARM machines) locally and to run these same
+images on container platforms (mostly AWS ECS) in production.
 
 Main goals:
+- Production-ready - run same images for local development and in production
 - As near as possible to the official images
 - Configuration through environment variables
 - Using best practices which proved good with our PHP projects in the last years
@@ -36,9 +38,9 @@ Available tags:
 * `croneu/phpapp-fpm:php-8.2`
 * `croneu/phpapp-fpm:php-8.1`
 * `croneu/phpapp-fpm:php-7.4`
-* `croneu/phpapp-fpm:php-7.3`
-* `croneu/phpapp-fpm:php-7.2`
-* `croneu/phpapp-fpm:php-7.0`
+* `croneu/phpapp-fpm:php-7.3` - no longer updated
+* `croneu/phpapp-fpm:php-7.2` - no longer updated
+* `croneu/phpapp-fpm:php-7.0` - no longer updated
 
 PHP runs as PHP-FPM (image `croneu/phpapp-fpm`), based on the offical images. 
 Use the `croneu/phpapp-web` container to be able to access this from a browser.
@@ -91,9 +93,9 @@ Available tags:
 * `croneu/phpapp-ssh:php-7.4-node-14`
 * `croneu/phpapp-ssh:php-7.4-node-12`
 * `croneu/phpapp-ssh:php-7.4-node-10`
-* `croneu/phpapp-ssh:php-7.3-node-10`
-* `croneu/phpapp-ssh:php-7.2-node-10`
-* `croneu/phpapp-ssh:php-7.0-node-14`
+* `croneu/phpapp-ssh:php-7.3-node-10` - no longer updated
+* `croneu/phpapp-ssh:php-7.2-node-10` - no longer updated
+* `croneu/phpapp-ssh:php-7.0-node-14` - no longer updated
 
 You can start a container for SSH'ing into it for development purposes with the image
 `croneu/phpapp-ssh`. It is based off the `phpapp-fpm` image (thus it contains the exact same
@@ -191,10 +193,16 @@ ssh -A -p 1122 application@my-app.vm
 
 Build is triggered automatically via Github Actions.
 
-To create them locally for testing purposes (and load created images to your docker):
+To create them locally for testing purposes (and load created images to your docker).
 
+Image `croneu/phpapp-ssh:php-8.1-node-16`:
 ```
-make build-ssh BUILDX_OPTIONS=--load PHP_VERSION=7.4 NODE_VERSION=16 PLATFORMS=linux/amd64
+make build-ssh PHP_VERSION=8.1 NODE_VERSION=16
+```
+
+Image `croneu/phpapp-fpm:php-8.1`:
+```
+make build-fpm PHP_VERSION=8.1
 ```
 
 ### Test the Docker Image


### PR DESCRIPTION
* Remove deprecations by using latest version of GHA
* Use [docker/build-push-action](https://github.com/docker/build-push-action) instead of Makefile targets for GHA building and pushing
* Use "gha" caching instead of doing our own "caching"
* Do not build PHP 7.0, 7.2, 7.3 anymore