### PR TITLE
Fail-safe curls (fail on errors)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ RUN <<EOF
 		# Letsencrypt certificate no longer valid
 		mkdir -p /usr/share/ca-certificates/letsencrypt/ \
 			&& cd /usr/share/ca-certificates/letsencrypt/ \
-			&& curl -kLO https://letsencrypt.org/certs/isrgrootx1.pem \
+			&& curl -kfsSLO https://letsencrypt.org/certs/isrgrootx1.pem \
 			&& perl -i.bak -pe 's/^(mozilla\/DST_Root_CA_X3.crt)/!$1/g' /etc/ca-certificates.conf \
 			&& update-ca-certificates
 	fi
@@ -87,7 +87,7 @@ RUN <<-EOF
     test "$CODENAME" = "bullseye" && VERSION=0.12.6.1-2
     PLATFORM=arm64
     test $(uname -m) = "x86_64" && PLATFORM=amd64
-    curl -L -o wkhtmltox.deb https://github.com/wkhtmltopdf/packaging/releases/download/${VERSION}/wkhtmltox_${VERSION}.${CODENAME}_${PLATFORM}.deb
+    curl -fsSL -o wkhtmltox.deb https://github.com/wkhtmltopdf/packaging/releases/download/${VERSION}/wkhtmltox_${VERSION}.${CODENAME}_${PLATFORM}.deb
     dpkg -i wkhtmltox.deb
     ln -s /usr/local/bin/wkhtmltopdf /usr/bin && ln -s /usr/local/bin/wkhtmltoimage /usr/bin
     rm -rf wkhtmltox.deb /var/lib/apt/lists/*
@@ -181,7 +181,7 @@ RUN set -ex \
 
 # Install node (pin, so that in doubt, the debian version is never installed)
 RUN (echo "Package: *" && echo "Pin: origin deb.nodesource.com" && echo "Pin-Priority: 1000") > /etc/apt/preferences.d/nodesource && \
-    curl -sL https://deb.nodesource.com/setup_${NODE_VERSION}.x | sudo -E bash - && \
+    curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | sudo -E bash - && \
     sudo apt-get -q install -y -V nodejs && \
     rm -rf /var/lib/apt/lists/*
 
@@ -193,7 +193,7 @@ RUN <<-EOF
     set -ex
     latest_url=https://github.com/cron-eu/clitools/releases/download/2.8.0/clitools.phar
     test "${PHP_MINOR_VERSION}" = "7.0" && latest_url=https://github.com/kitzberger/clitools/releases/download/2.5.4/clitools.phar
-    curl -Lo /usr/local/bin/ct $latest_url
+    curl -fsSLo /usr/local/bin/ct $latest_url
     chmod 777 /usr/local/bin/ct
 EOF
 
@@ -201,7 +201,7 @@ EOF
 RUN usermod -s /bin/bash root
 
 # Install composer
-RUN curl --silent --show-error https://getcomposer.org/installer | php && mv composer.phar /usr/local/bin/composer
+RUN curl -fsSL https://getcomposer.org/installer | php && mv composer.phar /usr/local/bin/composer
 
 # Enable HEALTHCHECK for SSH container
 HEALTHCHECK --interval=5s --timeout=1s CMD pgrep sshd > /dev/null || exit 1

--- a/files/ssh/github-keys.sh
+++ b/files/ssh/github-keys.sh
@@ -3,4 +3,4 @@
 user=$1
 mkdir -p ~/.ssh
 echo "# $user@github.com" >>  ~/.ssh/authorized_keys
-curl -s https://github.com/$user.keys >>  ~/.ssh/authorized_keys
+curl -sL https://github.com/$user.keys >>  ~/.ssh/authorized_keys

--- a/files/ssh/gitlab-keys.sh
+++ b/files/ssh/gitlab-keys.sh
@@ -8,7 +8,7 @@ IFS="$(printf '\n\t')"
 
 user=$1
 server=$2
-api_response=$(curl -k -sSLi https://${server}/${user}.keys)
+api_response=$(curl -ksSL https://${server}/${user}.keys)
 keys=$(echo "$api_response" | grep -o -E 'ssh-\w+\s+[^\"]+')
 
 if [ -z "$keys" ]; then


### PR DESCRIPTION
Add the "-f" flag to all curl calls, so that the building fails if there is any failed HTTP request.

Most calls use:
`-f` = fail on error
`-s` = silence (no progress reporting)
`-S` = show error even if -s
`-L` = follow redirects

Some calls use additionally:
`-o` = output to named file
`-O` = output to file with same name as downloaded resource

One uses:
`-k` = do not fail on SSL errors, only for the legacy code