### PR TITLE
Use default PHP variables_order (EGPCS)

### DIFF
--- a/files/php.ini
+++ b/files/php.ini
@@ -7,7 +7,6 @@
 display_errors = 1
 
 short_open_tag = On
-variables_order = 'GPCS'
 request_order = 'GP'
 
 allow_url_fopen = On


### PR DESCRIPTION
Current default does not fill in `$_ENV` variables. Use the default from PHP, so that we also have a filled in `$_ENV`.

See https://www.php.net/manual/en/ini.core.php#ini.variables-order - Defaults to `EGPCS`.