### PR TITLE
Add PHP v8.3 and Node v20 option

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -16,6 +16,7 @@ jobs:
     strategy:
       matrix:
         include:
+          - php-version: "8.3"
           - php-version: "8.2"
           - php-version: "8.1"
           - php-version: "7.4"
@@ -71,6 +72,8 @@ jobs:
     strategy:
       matrix:
         include:
+          - php-version: "8.3"
+            node-version: "20"
           - php-version: "8.2"
             node-version: "18"
           - php-version: "8.1"

--- a/.github/workflows/build-only.yml
+++ b/.github/workflows/build-only.yml
@@ -17,6 +17,7 @@ jobs:
     strategy:
       matrix:
         include:
+          - php-version: "8.3"
           - php-version: "8.2"
           - php-version: "8.1"
           - php-version: "7.4"
@@ -50,6 +51,8 @@ jobs:
     strategy:
       matrix:
         include:
+          - php-version: "8.3"
+            node-version: "20"
           - php-version: "8.2"
             node-version: "18"
           - php-version: "8.1"

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Additionally, it includes the following utilities for TYPO3 specific workflows:
 
 Available tags:
 
+* `croneu/phpapp-ssh:php-8.3-node-20`
 * `croneu/phpapp-ssh:php-8.2-node-18`
 * `croneu/phpapp-ssh:php-8.1-node-16`
 * `croneu/phpapp-ssh:php-7.4-node-16`


### PR DESCRIPTION
Cutting Edge for 2024

* PHP v8.3 https://www.php.net/supported-versions.php
* Node v20 https://nodejs.org/en/about/previous-releases#release-schedule
* Usage for latest TYPO3 v12 and possible v13 projects, see https://typo3.org/cms/roadmap