### PR TITLE
Fix /home/application being "write for all" (SSH login not working anymore)

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -45,6 +45,7 @@ jobs:
       - name: "Docker build and push (fpm image)"
         uses: docker/build-push-action@v4
         with:
+          context: .
           tags: "croneu/phpapp-fpm:php-${{ matrix.php-version }}"
           platforms: ${{ env.PLATFORMS }}
           push: true
@@ -103,6 +104,7 @@ jobs:
       - name: "Docker build and push (ssh image)"
         uses: docker/build-push-action@v4
         with:
+          context: .
           tags: "croneu/phpapp-ssh:php-${{ matrix.php-version }}-node-${{ matrix.node-version }}"
           platforms: ${{ env.PLATFORMS }}
           push: true

--- a/.github/workflows/build-only.yml
+++ b/.github/workflows/build-only.yml
@@ -32,6 +32,7 @@ jobs:
       - name: "Docker build only (fpm image)"
         uses: docker/build-push-action@v4
         with:
+          context: .
           tags: "croneu/phpapp-fpm:php-${{ matrix.php-version }}"
           platforms: ${{ env.PLATFORMS }}
           push: false
@@ -68,6 +69,7 @@ jobs:
       - name: "Docker build only (ssh image)"
         uses: docker/build-push-action@v4
         with:
+          context: .
           tags: "croneu/phpapp-ssh:php-${{ matrix.php-version }}-node-${{ matrix.node-version }}"
           platforms: ${{ env.PLATFORMS }}
           push: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -123,7 +123,7 @@ RUN rm -f /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 
 # Add entrypoint scripts
 COPY files/entrypoint*.sh /
-RUN chmod +x /*.sh
+RUN chmod 755 /*.sh
 
 # Configure PHP and PHP-FPM
 ADD files/php.ini /usr/local/etc/php/conf.d/zz-01-custom.ini
@@ -214,10 +214,18 @@ HEALTHCHECK --interval=5s --timeout=1s CMD pgrep sshd > /dev/null || exit 1
 RUN usermod -s /bin/bash application
 
 COPY files/ssh/ /
+COPY files/entrypoint-extras.sh /
+# Fix permissions of copied files
+RUN <<-EOF
+    set -ex
+    chmod 755 /etc /etc/profile.d /etc/profile.d/docker-prompt.sh
+    find /home -type d -exec chmod 755 {} \;
+    find /home -type f -exec chmod 644 {} \;
+    chmod 755 /*.sh
+EOF
 
 # Disable XDEBUG by default (can be enabled via XDEBUG_MODE in entrypoint-extras.sh
 RUN rm -f /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
-COPY files/entrypoint-extras.sh /
 
 RUN chmod +x /*.sh && chown -R application: /home/application
 


### PR DESCRIPTION
The "docker build" in "git context" used by the Github Actions seem to work differently now, using an "umask 000", so that all files which are being `COPY` in the `Dockerfile` will get a "666/777" permissions. And thus the SSH login won't work anymore:
```
Authentication refused: bad ownership or modes for directory /home/application/.ssh
```

We fix that in two ways:
* Do not use the docker build "git context" in the github action anymore, instead we rely on the `actions/checkout@v3` action which we are doing anyway before it
* Make sure the permissions are fixed after the `COPY` instructions