### PR TITLE
Add redis-cli to ssh image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -169,12 +169,15 @@ RUN apt-get -qq update && apt-get -q install -y \
         wget \
         joe \
         jq \
+        redis-tools \
         rsync \
         patch \
         screen \
         # for causal/extractor: \
         exiftool poppler-utils \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /usr/share/doc \
+    && rm -f /usr/bin/redis-benchmark /usr/bin/redis-check-aof /usr/bin/redis-check-rdb
 
 # Configure ssh daemon
 RUN set -ex \

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ the application from the command line:
 * Convenience tools: git, zip, make, ping, less, vi, wget, joe, jq, rsync, patch
 * clitools from WebdevOps
 * MySQL client
+* redis-cli
 * GraphicsMagick
 * exiftool, poppler-utils
 


### PR DESCRIPTION
Only "redis-cli" and not the other tools which are included in the package `redis-tools`, to avoid bloating the image even more.

Also remove the /usr/share/doc bloat from the image anyway.