### PR TITLE
Fix exported env variables to ssh users (also include those with spaces)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 
 # For local testing
 
-PLATFORMS=linux/amd64
-#PLATFORMS=linux/arm64/v8
+#PLATFORMS=linux/amd64
+PLATFORMS=linux/arm64/v8
 
 # Defaults:
-PHP_VERSION=8.1
-NODE_VERSION=16
+PHP_VERSION=8.3
+NODE_VERSION=20
 
 BUILDX_OPTIONS=--load
 DOCKER_CACHE_PATH=.buildx-cache

--- a/example-app/docker-compose.yml
+++ b/example-app/docker-compose.yml
@@ -19,7 +19,7 @@ services:
           - example-app.vm
 
   php:
-    image: croneu/phpapp-fpm:php-8.1
+    image: croneu/phpapp-fpm:php-8.3
     env_file:
       - '.env.docker'
       - '.env'
@@ -27,7 +27,7 @@ services:
       - app:/app
 
   ssh:
-    image: croneu/phpapp-ssh:php-8.1-node-16
+    image: croneu/phpapp-ssh:php-8.3-node-20
     ports:
       - '1122:22'
     volumes:


### PR DESCRIPTION
New logic to pass env variables from the container to the SSH user. Now instead of doing a fancy "grep" we do some even more fancy gathering which variables are already set for the user and skip those explicitly.

We also skip multi-line variables because this is not supported by the `/etc/environment`.