### PR TITLE
Useful information when logging in to SSH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -163,6 +163,7 @@ RUN apt-get -qq update && apt-get -q install -y \
         bash \
         bash-completion \
         default-mysql-client \
+        figlet \
         iputils-ping \
         less \
         vim \
@@ -207,6 +208,9 @@ EOF
 
 # Also root uses bash
 RUN usermod -s /bin/bash root
+
+# No Debian motd, we have our own "login information" in application's user .bash_profile
+RUN rm -f /etc/motd
 
 # Install composer
 RUN curl -fsSL https://getcomposer.org/installer | php && mv composer.phar /usr/local/bin/composer

--- a/README.md
+++ b/README.md
@@ -198,14 +198,14 @@ Build is triggered automatically via Github Actions.
 
 To create them locally for testing purposes (and load created images to your docker).
 
-Image `croneu/phpapp-ssh:php-8.1-node-16`:
+Image `croneu/phpapp-ssh:php-8.3-node-20`:
 ```
-make build-ssh PHP_VERSION=8.1 NODE_VERSION=16
+make build-ssh PHP_VERSION=8.3 NODE_VERSION=20 DOCKER_CACHE=
 ```
 
-Image `croneu/phpapp-fpm:php-8.1`:
+Image `croneu/phpapp-fpm:php-8.3`:
 ```
-make build-fpm PHP_VERSION=8.1
+make build-fpm PHP_VERSION=8.3 DOCKER_CACHE=
 ```
 
 ### Test the Docker Image

--- a/example-app/docker-compose.yml
+++ b/example-app/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 # Example docker-compose using the images we build here
 
 services:

--- a/files/ssh/home/application/.bash_profile
+++ b/files/ssh/home/application/.bash_profile
@@ -4,4 +4,16 @@ shopt -s histappend
 export PROMPT_COMMAND='history -a'
 export HISTSIZE=10000
 
+if [[ $- == *i* ]]; then
+    # Interative shell, print out some information
+    URL=$(env | egrep "BASE_?URL" | head -1 | cut -f 2 -d "=")
+    test ! -z "$ENV" && figlet "$ENV" && printf "\n"
+    test ! -z "$ENV" && printf "%15s: %s\n" "ENV" "$ENV"
+    test ! -z "$AWS_LOG_GROUP" && printf "%15s: %s\n" "AWS_LOG_GROUP" "$AWS_LOG_GROUP"
+    test ! -z "$URL" && printf "%15s: %s\n" "BASE_URL" "$URL"
+    test ! -z "$TYPO3_CONTEXT" && printf "%15s: %s\n" "TYPO3_CONTEXT" "$TYPO3_CONTEXT"
+    test ! -z "$PHP_VERSION" && printf "%15s: %s\n" "PHP_VERSION" "$PHP_VERSION"
+    printf "\n"
+fi
+
 cd "/app"

--- a/files/ssh/home/application/.bash_profile
+++ b/files/ssh/home/application/.bash_profile
@@ -12,6 +12,7 @@ if [[ $- == *i* ]]; then
     test ! -z "$AWS_LOG_GROUP" && printf "%15s: %s\n" "AWS_LOG_GROUP" "$AWS_LOG_GROUP"
     test ! -z "$URL" && printf "%15s: %s\n" "BASE_URL" "$URL"
     test ! -z "$TYPO3_CONTEXT" && printf "%15s: %s\n" "TYPO3_CONTEXT" "$TYPO3_CONTEXT"
+    test ! -z "$FLOW_CONTEXT" && printf "%15s: %s\n" "FLOW_CONTEXT" "$FLOW_CONTEXT"
     test ! -z "$PHP_VERSION" && printf "%15s: %s\n" "PHP_VERSION" "$PHP_VERSION"
     printf "\n"
 fi


### PR DESCRIPTION
Show some useful information when logging in as `application` user via SSH:

Useful ENV variables are shown: `ENV`, `AWS_LOG_GROUP`, `BASE_URL`, `TYPO3_CONTEXT`, `FLOW_CONTEXT`, `PHP_VERSION`.

The `ENV` is show nicely using `figlet`:

```
❯ make docker-ssh
ssh -A -p 1122 application@"127.0.0.1"
Linux 90a265d4c6f9 6.12.9-orbstack-00297-gaa9b46293ea3 #40 SMP Tue Jan 14 03:41:26 UTC 2025 aarch64
                                _                              
  _____  ____ _ _ __ ___  _ __ | | ___        __ _ _ __  _ __  
 / _ \ \/ / _` | '_ ` _ \| '_ \| |/ _ \_____ / _` | '_ \| '_ \ 
|  __/>  < (_| | | | | | | |_) | |  __/_____| (_| | |_) | |_) |
 \___/_/\_\__,_|_| |_| |_| .__/|_|\___|      \__,_| .__/| .__/ 
                         |_|                      |_|   |_|    

            ENV: example-app
    PHP_VERSION: 8.3.16
```
