### PR TITLE
Add PHP 8.4 with Node 22

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -16,6 +16,7 @@ jobs:
     strategy:
       matrix:
         include:
+          - php-version: "8.4"
           - php-version: "8.3"
           - php-version: "8.2"
           - php-version: "8.1"
@@ -72,6 +73,8 @@ jobs:
     strategy:
       matrix:
         include:
+          - php-version: "8.4"
+            node-version: "22"
           - php-version: "8.3"
             node-version: "20"
           - php-version: "8.2"

--- a/.github/workflows/build-only.yml
+++ b/.github/workflows/build-only.yml
@@ -17,6 +17,7 @@ jobs:
     strategy:
       matrix:
         include:
+          - php-version: "8.4"
           - php-version: "8.3"
           - php-version: "8.2"
           - php-version: "8.1"
@@ -51,6 +52,8 @@ jobs:
     strategy:
       matrix:
         include:
+          - php-version: "8.4"
+            node-version: "22"
           - php-version: "8.3"
             node-version: "20"
           - php-version: "8.2"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@
 # Dockerfile to build the "fpm"" and "ssh" images
 # -------------------------------------------------------------------------
 
-ARG PHP_MINOR_VERSION=8.2
-ARG NODE_VERSION=18
+ARG PHP_MINOR_VERSION=8.4
+ARG NODE_VERSION=20
 
 # -------------------------------------------------------------------------
 
@@ -39,8 +39,8 @@ RUN <<EOT bash
       "gd"
       "gettext"
       "igbinary"
+      "imagick"
       "intl"
-      "mcrypt"
       "mysqli"
       "opcache"
       "pcntl"
@@ -57,12 +57,14 @@ RUN <<EOT bash
       "yaml"
       "zip"
     )
-    if [[ "$PHP_MINOR_VERSION" == "8.3" ]]; then
-        # Workaround, see https://github.com/mlocati/docker-php-extension-installer/pull/811
-        PHP_EXTENSIONS+=("imagick/imagick@master")
-    else
-        PHP_EXTENSIONS+=("imagick")
-    fi
+    case "$PHP_MINOR_VERSION" in
+        "8.0"|"8.1"|"8.2"|"8.3")
+          # Legacy deprecated extension, but we had it until 8.3:
+          PHP_EXTENSIONS+=("mcrypt")
+          ;;
+        *)
+          ;;
+    esac
     install-php-extensions \${PHP_EXTENSIONS[@]}
 EOT
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Related:
 
 Available tags:
 
+* `croneu/phpapp-fpm:php-8.4`
 * `croneu/phpapp-fpm:php-8.3`
 * `croneu/phpapp-fpm:php-8.2`
 * `croneu/phpapp-fpm:php-8.1`
@@ -58,7 +59,7 @@ This image includes the following additional extensions:
 * igbinary
 * imagick
 * intl
-* mcrypt
+* mcrypt (no longer with PHP 8.4 - long deprecated)
 * mysqli
 * opcache
 * pcntl
@@ -88,6 +89,7 @@ Additionally, it includes the following utilities for TYPO3 specific workflows:
 
 Available tags:
 
+* `croneu/phpapp-ssh:php-8.4-node-22`
 * `croneu/phpapp-ssh:php-8.3-node-20`
 * `croneu/phpapp-ssh:php-8.2-node-18`
 * `croneu/phpapp-ssh:php-8.1-node-16`
@@ -119,13 +121,13 @@ You can also use the `phpapp-ssh` image to run one-time containers to execute ce
 with the same setup. I.e.:
 
 ```
-docker run -v .:/app --rm croneu/phpapp-ssh:php-8.2-node-18 make test 
+docker run -v .:/app --rm croneu/phpapp-ssh:php-8.4-node-22 make test 
 ```
 
 Or in docker-compose:
 ```
   test:
-    image: croneu/phpapp-ssh:php-8.2-node-18
+    image: croneu/phpapp-ssh:php-8.4-node-22
     command: make test
     volumes:
       - .:/app
@@ -198,14 +200,14 @@ Build is triggered automatically via Github Actions.
 
 To create them locally for testing purposes (and load created images to your docker).
 
-Image `croneu/phpapp-ssh:php-8.3-node-20`:
+Image `croneu/phpapp-ssh:php-8.4-node-22`:
 ```
-make build-ssh PHP_VERSION=8.3 NODE_VERSION=20 DOCKER_CACHE=
+make build-ssh PHP_VERSION=8.4 NODE_VERSION=22 DOCKER_CACHE=
 ```
 
-Image `croneu/phpapp-fpm:php-8.3`:
+Image `croneu/phpapp-fpm:php-8.4`:
 ```
-make build-fpm PHP_VERSION=8.3 DOCKER_CACHE=
+make build-fpm PHP_VERSION=8.4 DOCKER_CACHE=
 ```
 
 ### Test the Docker Image

--- a/example-app/docker-compose.yml
+++ b/example-app/docker-compose.yml
@@ -17,7 +17,7 @@ services:
           - example-app.vm
 
   php:
-    image: croneu/phpapp-fpm:php-8.3
+    image: croneu/phpapp-fpm:php-8.4
     env_file:
       - '.env.docker'
       - '.env'
@@ -25,7 +25,7 @@ services:
       - app:/app
 
   ssh:
-    image: croneu/phpapp-ssh:php-8.3-node-20
+    image: croneu/phpapp-ssh:php-8.4-node-22
     ports:
       - '1122:22'
     volumes:


### PR DESCRIPTION
Notes:
* mcrypt: in PHP 8.4 we no longer ship with "mcrypt" (deprecated since several years)
* imagick: we now use "stable" imagick extension again (no longer @master workaround, issue was solved meanwhile)