### PR TITLE
Allow disabling unneeded extensions with PHP_DISABLE_EXTENSIONS

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Application root is `/app`. Application runs as user `application` (uid=1000).
 | `ENV`                                  | ssh      |             | The name of the environment to show on the shell prompt                                                                                  |
 | `PHP_INI_OVERRIDE`                     | fpm, ssh |             | Allow overriding php.ini settings. Simply the multiline content for a php.ini here. Use "\n" for multiline i.e. in ECS                   |
 | `PHP_FPM_OVERRIDE`                     | fpm      |             | Allow overriding php-fpm pool settings. The multiline content for php-fpm.conf here. Use "\n" for multiline i.e. in ECS                  |
+| `PHP_DISABLE_EXTENSIONS`               | fpm, ssh |             | Comma separated list of PHP extensions to disable.                                                                                       |
 
 ## Example usage
 

--- a/example-app/.env.example
+++ b/example-app/.env.example
@@ -25,6 +25,10 @@ DB_NAME=typo3
 # PHP settings overrides (examples)
 # -----------------------------------------
 
+# See full list here:
+# https://github.com/cron-eu/docker-phpapp-php/blob/master/README.md#php-fpm-image-croneuphpapp-fpm
+#PHP_DISABLE_EXTENSIONS=igbinary,redis
+
 PHP_INI_OVERRIDE="
 upload_max_filesize = 256M
 post_max_size = 256M

--- a/files/entrypoint-extras.sh
+++ b/files/entrypoint-extras.sh
@@ -10,8 +10,22 @@ if [ -z "${XDEBUG_MODE}" ] || [ "${XDEBUG_MODE}" = "off" ]; then
   # completely not load xdebug if its off
   rm -f /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 else
-  echo "* enabling XDEBUG: $XDEBUG_MODE"
+  echo "* Enabling XDEBUG: $XDEBUG_MODE"
   echo "zend_extension=xdebug.so" > /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+fi
+
+# Enable all extensions which might have been disabled at some point first
+if ls /usr/local/etc/php/conf.d/*php-ext*.disabled 1> /dev/null 2>&1; then
+  for file in /usr/local/etc/php/conf.d/*php-ext*.disabled; do
+    mv "$file" "${file%.disabled}"
+  done
+fi
+# Disable extensions based on PHP_DISABLE_EXTENSIONS
+if [ ! -z "${PHP_DISABLE_EXTENSIONS}" ]; then
+  for ext in $(echo $PHP_DISABLE_EXTENSIONS | sed -e 's/,/ /g'); do
+    echo "* Disabling PHP extension: $ext"
+    mv /usr/local/etc/php/conf.d/docker-php-ext-$ext.ini /usr/local/etc/php/conf.d/docker-php-ext-$ext.ini.disabled
+  done
 fi
 
 if [ ! -z "${APPLICATION_UID}" ]; then

--- a/files/entrypoint-extras.sh
+++ b/files/entrypoint-extras.sh
@@ -23,8 +23,12 @@ fi
 # Disable extensions based on PHP_DISABLE_EXTENSIONS
 if [ ! -z "${PHP_DISABLE_EXTENSIONS}" ]; then
   for ext in $(echo $PHP_DISABLE_EXTENSIONS | sed -e 's/,/ /g'); do
-    echo "* Disabling PHP extension: $ext"
-    mv /usr/local/etc/php/conf.d/docker-php-ext-$ext.ini /usr/local/etc/php/conf.d/docker-php-ext-$ext.ini.disabled
+    if [ -f "/usr/local/etc/php/conf.d/docker-php-ext-$ext.ini" ]; then
+      echo "* Disabling PHP extension: $ext"
+      mv /usr/local/etc/php/conf.d/docker-php-ext-$ext.ini /usr/local/etc/php/conf.d/docker-php-ext-$ext.ini.disabled
+    else
+      echo "* WARNING: PHP extension $ext not found, cannot disable"
+    fi
   done
 fi
 


### PR DESCRIPTION
Set `PHP_DISABLE_EXTENSIONS` to a comma separated list of extensions to disable when starting the containers. This allows to avoid bugs (i.e. disabling `igbinary`) or lower memory footprint by not loading extensions you do not need (i.e. `redis`, `soap`, ...).