### PR TITLE
Add vips and ffi extensions and PHP_EXTENSIONS setting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,8 @@ COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr
 RUN <<EOT bash
     set -ex
     PHP_EXTENSIONS=(
+      "apcu"
+      "bcmath"
       "bz2"
       "calendar"
       "exif"

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,7 @@ RUN <<EOT bash
       "sysvsem"
       "sysvshm"
       "uuid"
+      "vips"
       "xdebug"
       "yaml"
       "zip"

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ RUN <<EOT bash
       "bz2"
       "calendar"
       "exif"
+      "ffi"
       "gd"
       "gettext"
       "imagick"

--- a/README.md
+++ b/README.md
@@ -76,7 +76,12 @@ This image includes the following additional extensions:
 * yaml
 * zip
 
-Additionally, it includes the following utilities for TYPO3 specific workflows:
+All extensions are enabled by default. If you want to only disable some of them,
+you can use the setting `PHP_DISABLE_EXTENSIONS` in the environment variables.
+If you want to override the list of enabled extensions, you can use the
+`PHP_EXTENSIONS` environment variable.
+
+Additionally, the image includes the following utilities for TYPO3 specific workflows:
 
 * GraphicsMagick
 * curl
@@ -141,22 +146,23 @@ Application root is `/app`. Application runs as user `application` (uid=1000).
 
 ### Settings (through environment variables)
 
-| Setting                                | Image    | Default     | Description                                                                                                                              |
-|----------------------------------------|----------|-------------|------------------------------------------------------------------------------------------------------------------------------------------|
-| `XDEBUG_MODE`                          | fpm, ssh | debug       | Or set to `develop` (slow) or `none` to turn it off completely. See https://xdebug.org/docs/all_settings#mode                            |
+| Setting                                    | Image    | Default     | Description                                                                                                                              |
+|--------------------------------------------|----------|-------------|------------------------------------------------------------------------------------------------------------------------------------------|
+| `XDEBUG_MODE`                              | fpm, ssh | debug       | Or set to `develop` (slow) or `none` to turn it off completely. See https://xdebug.org/docs/all_settings#mode                            |
 | `DB_HOST`, `DB_USER`, `DB_PASS`, `DB_NAME` | ssh      |             | These will create a `.my.cnf` for the user. You can use the same variables in your  `docker-compose.yml` to configure the MariaDB image. |
 | `APPLICATION_UID`, `APPLICATION_GID`       | fpm, ssh | 1000, 1000  | UID and GID for the application user. Change to match your local user in case you use bind-mounts (Linux only)                           |
-| `IMPORT_GITLAB_SERVER`                 | ssh      | git.cron.eu | Gitlab instance to import SSH key from                                                                                                   |
-| `IMPORT_GITLAB_PUB_KEYS`               | ssh      |             | Gitlab user to import SSH keys from                                                                                                      |
-| `IMPORT_GITHUB_PUB_KEYS`               | ssh      |             | GitHub user to import SSH keys from                                                                                                      |
-| `IMPORT_PUB_KEYS`                      | ssh      |             | Additional SSH public keys to load, comma separated                                                                                      |
-| `SSH_CONFIG`                           | ssh      |             | The whole content of the `.ssh/config` file                                                                                              |
-| `SSH_KNOWN_HOSTS`                      | ssh      |             | The whole content of the `.ssh/known_hosts` file                                                                                         |
-| `SSH_PRIVATE_KEY`                      | ssh      |             | A SSH private key to load in an `ssh-agent`, useful if you run a SSH container with commands                                             |                                                    |
-| `ENV`                                  | ssh      |             | The name of the environment to show on the shell prompt                                                                                  |
-| `PHP_INI_OVERRIDE`                     | fpm, ssh |             | Allow overriding php.ini settings. Simply the multiline content for a php.ini here. Use "\n" for multiline i.e. in ECS                   |
-| `PHP_FPM_OVERRIDE`                     | fpm      |             | Allow overriding php-fpm pool settings. The multiline content for php-fpm.conf here. Use "\n" for multiline i.e. in ECS                  |
-| `PHP_DISABLE_EXTENSIONS`               | fpm, ssh |             | Comma separated list of PHP extensions to disable.                                                                                       |
+| `IMPORT_GITLAB_SERVER`                     | ssh      | git.cron.eu | Gitlab instance to import SSH key from                                                                                                   |
+| `IMPORT_GITLAB_PUB_KEYS`                   | ssh      |             | Gitlab user to import SSH keys from                                                                                                      |
+| `IMPORT_GITHUB_PUB_KEYS`                   | ssh      |             | GitHub user to import SSH keys from                                                                                                      |
+| `IMPORT_PUB_KEYS`                          | ssh      |             | Additional SSH public keys to load, comma separated                                                                                      |
+| `SSH_CONFIG`                               | ssh      |             | The whole content of the `.ssh/config` file                                                                                              |
+| `SSH_KNOWN_HOSTS`                          | ssh      |             | The whole content of the `.ssh/known_hosts` file                                                                                         |
+| `SSH_PRIVATE_KEY`                          | ssh      |             | A SSH private key to load in an `ssh-agent`, useful if you run a SSH container with commands                                             |                                                    |
+| `ENV`                                      | ssh      |             | The name of the environment to show on the shell prompt                                                                                  |
+| `PHP_INI_OVERRIDE`                         | fpm, ssh |             | Allow overriding php.ini settings. Simply the multiline content for a php.ini here. Use "\n" for multiline i.e. in ECS                   |
+| `PHP_FPM_OVERRIDE`                         | fpm      |             | Allow overriding php-fpm pool settings. The multiline content for php-fpm.conf here. Use "\n" for multiline i.e. in ECS                  |
+| `PHP_EXTENSIONS`                           | fpm, ssh | (all)       | Comma separated list of PHP extensions to enable (if this is not set, all are enabled).                                                  |
+| `PHP_DISABLE_EXTENSIONS`                   | fpm, ssh |             | Comma separated list of PHP extensions to disable (in case you keep all enabled, you can disable individual ones, i.e. igbinary).        |
 
 ## Example usage
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ This image includes the following additional extensions:
 * sysvsem
 * sysvshm
 * uuid
+* vips
 * xdebug
 * yaml
 * zip

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ This image includes the following additional extensions:
 * bz2
 * calendar
 * exif
+* ffi
 * gd
 * gettext
 * igbinary

--- a/example-app/.env.docker
+++ b/example-app/.env.docker
@@ -12,6 +12,9 @@
 # See https://xdebug.org/docs/develop#mode
 XDEBUG_MODE=debug
 
+# If you only want a specific subset of extensions enabled. This is the default set of all:
+#PHP_EXTENSIONS=apcu,bcmath,bz2,calendar,exif,gd,gettext,imagick,intl,mysqli,opcache,pcntl,pdo_mysql,redis,shmop,soap,sockets,sysvmsg,sysvsem,sysvshm,uuid,xdebug,yaml,zip
+
 # -----------------------------------------
 # For the ssh container
 # -----------------------------------------

--- a/example-app/.env.docker
+++ b/example-app/.env.docker
@@ -13,7 +13,9 @@
 XDEBUG_MODE=debug
 
 # If you only want a specific subset of extensions enabled. This is the default set of all:
-#PHP_EXTENSIONS=apcu,bcmath,bz2,calendar,exif,gd,gettext,imagick,intl,mysqli,opcache,pcntl,pdo_mysql,redis,shmop,soap,sockets,sysvmsg,sysvsem,sysvshm,uuid,xdebug,yaml,zip
+#PHP_EXTENSIONS=apcu,bcmath,bz2,calendar,exif,gd,gettext,imagick,intl,mysqli,opcache,pcntl,pdo_mysql,redis,shmop,soap,sockets,sysvmsg,sysvsem,sysvshm,uuid,vips,xdebug,yaml,zip
+# Baseline, minimal set of extensions that are required for most applications
+#PHP_EXTENSIONS=apcu,bcmath,bz2,calendar,exif,gd,gettext,intl,mysqli,opcache,pdo_mysql,zip,yaml
 
 # -----------------------------------------
 # For the ssh container

--- a/example-app/.env.docker
+++ b/example-app/.env.docker
@@ -13,7 +13,7 @@
 XDEBUG_MODE=debug
 
 # If you only want a specific subset of extensions enabled. This is the default set of all:
-#PHP_EXTENSIONS=apcu,bcmath,bz2,calendar,exif,gd,gettext,imagick,intl,mysqli,opcache,pcntl,pdo_mysql,redis,shmop,soap,sockets,sysvmsg,sysvsem,sysvshm,uuid,vips,xdebug,yaml,zip
+#PHP_EXTENSIONS=apcu,bcmath,bz2,calendar,exif,ffi,gd,gettext,imagick,intl,mysqli,opcache,pcntl,pdo_mysql,redis,shmop,soap,sockets,sysvmsg,sysvsem,sysvshm,uuid,vips,xdebug,yaml,zip
 # Baseline, minimal set of extensions that are required for most applications
 #PHP_EXTENSIONS=apcu,bcmath,bz2,calendar,exif,gd,gettext,intl,mysqli,opcache,pdo_mysql,zip,yaml
 

--- a/files/entrypoint-extras.sh
+++ b/files/entrypoint-extras.sh
@@ -5,15 +5,6 @@
 #
 # Mainly tweaking php settings based on ENV variables
 
-# Really disable XDEBUG if not required
-if [ -z "${XDEBUG_MODE}" ] || [ "${XDEBUG_MODE}" = "off" ]; then
-  # completely not load xdebug if its off
-  rm -f /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
-else
-  echo "* Enabling XDEBUG: $XDEBUG_MODE"
-  echo "zend_extension=xdebug.so" > /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
-fi
-
 # Controls which extensions are enabled.
 
 if [ ! -z "${PHP_EXTENSIONS}" ]; then
@@ -64,6 +55,17 @@ else
       fi
     done
   fi
+fi
+
+# Special handling for XDEBUG through XDEBUG_MODE:
+
+# Really disable XDEBUG if not required
+if [ -z "${XDEBUG_MODE}" ] || [ "${XDEBUG_MODE}" = "off" ]; then
+  # completely not load xdebug if its off
+  rm -f /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+else
+  echo "* Enabling XDEBUG: $XDEBUG_MODE"
+  echo "zend_extension=xdebug.so" > /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 fi
 
 if [ ! -z "${APPLICATION_UID}" ]; then

--- a/files/entrypoint-extras.sh
+++ b/files/entrypoint-extras.sh
@@ -14,22 +14,56 @@ else
   echo "zend_extension=xdebug.so" > /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 fi
 
-# Enable all extensions which might have been disabled at some point first
-if ls /usr/local/etc/php/conf.d/*php-ext*.disabled 1> /dev/null 2>&1; then
-  for file in /usr/local/etc/php/conf.d/*php-ext*.disabled; do
-    mv "$file" "${file%.disabled}"
-  done
-fi
-# Disable extensions based on PHP_DISABLE_EXTENSIONS
-if [ ! -z "${PHP_DISABLE_EXTENSIONS}" ]; then
-  for ext in $(echo $PHP_DISABLE_EXTENSIONS | sed -e 's/,/ /g'); do
-    if [ -f "/usr/local/etc/php/conf.d/docker-php-ext-$ext.ini" ]; then
-      echo "* Disabling PHP extension: $ext"
-      mv /usr/local/etc/php/conf.d/docker-php-ext-$ext.ini /usr/local/etc/php/conf.d/docker-php-ext-$ext.ini.disabled
+# Controls which extensions are enabled.
+
+if [ ! -z "${PHP_EXTENSIONS}" ]; then
+  # If PHP_EXTENSIONS is set: only enable the ones specified
+
+  echo "* PHP_EXTENSIONS: $PHP_EXTENSIONS"
+  echo "* Disabling all extensions and enabling only specified ones."
+
+  # First, disable all extensions by renaming them
+  if ls /usr/local/etc/php/conf.d/docker-php-ext-*.ini 1> /dev/null 2>&1; then
+    for file in /usr/local/etc/php/conf.d/docker-php-ext-*.ini; do
+      mv "$file" "$file.disabled"
+    done
+  fi
+
+  # Now, enable the extensions listed in PHP_EXTENSIONS
+  for ext in $(echo "$PHP_EXTENSIONS" | sed -e 's/,/ /g'); do
+    disabled_ext_file="/usr/local/etc/php/conf.d/docker-php-ext-$ext.ini.disabled"
+    enabled_ext_file="/usr/local/etc/php/conf.d/docker-php-ext-$ext.ini"
+
+    if [ -f "$disabled_ext_file" ]; then
+      echo "* Enabling PHP extension: $ext"
+      mv "$disabled_ext_file" "$enabled_ext_file"
+    elif [ -f "$enabled_ext_file" ]; then
+      # This case should not happen if the above disabling loop worked, but as a fallback.
+      echo "* PHP extension $ext was already enabled."
     else
-      echo "* WARNING: PHP extension $ext not found, cannot disable"
+      echo "* WARNING: PHP extension $ext not found, cannot enable."
     fi
   done
+else
+  # If PHP_EXTENSIONS is not set, all extensions are enabled by default.
+
+  # Enable all extensions which might have been disabled at some point first
+  if ls /usr/local/etc/php/conf.d/*php-ext*.disabled 1> /dev/null 2>&1; then
+    for file in /usr/local/etc/php/conf.d/*php-ext*.disabled; do
+      mv "$file" "${file%.disabled}"
+    done
+  fi
+  # Disable extensions based on PHP_DISABLE_EXTENSIONS
+  if [ ! -z "${PHP_DISABLE_EXTENSIONS}" ]; then
+    for ext in $(echo $PHP_DISABLE_EXTENSIONS | sed -e 's/,/ /g'); do
+      if [ -f "/usr/local/etc/php/conf.d/docker-php-ext-$ext.ini" ]; then
+        echo "* Disabling PHP extension: $ext"
+        mv /usr/local/etc/php/conf.d/docker-php-ext-$ext.ini /usr/local/etc/php/conf.d/docker-php-ext-$ext.ini.disabled
+      else
+        echo "* WARNING: PHP extension $ext not found, cannot disable"
+      fi
+    done
+  fi
 fi
 
 if [ ! -z "${APPLICATION_UID}" ]; then


### PR DESCRIPTION
Added new php extensions:
* vips
* ffi (for use with newer vips PHP package)

Allow to configure an exact list of extensions to load with PHP if you dont want the default (load all). New setting is called `PHP_EXTENSIONS`. Default is "empty" which is the original behaviour (load all compiled extensions).

All extensions means:

```
PHP_EXTENSIONS=apcu,bcmath,bz2,calendar,exif,ffi,gd,gettext,imagick,intl,mysqli,opcache,pcntl,pdo_mysql,redis,shmop,soap,sockets,sysvmsg,sysvsem,sysvshm,uuid,vips,xdebug,yaml,zip
```

A minimal set of extensions that are required for most applications:
```
PHP_EXTENSIONS=apcu,bcmath,bz2,calendar,exif,gd,gettext,intl,mysqli,opcache,pdo_mysql,yaml,zip
```

And then add from the remaining one the things you **really** need:
```
... imagick,pcntl,redis,shmop,soap,sockets,sysvmsg,sysvsem,sysvshm,uuid,vips,xdebug
```