### PR TITLE
Do not expose certain internal ENV variables to processes

### DIFF
--- a/files/entrypoint-extras.sh
+++ b/files/entrypoint-extras.sh
@@ -87,3 +87,17 @@ fi
 if [ ! -z "${PHP_INI_OVERRIDE}" ]; then
   echo "${PHP_INI_OVERRIDE}" | sed -e 's/\\n/\n/g' > /usr/local/etc/php/conf.d/zz-02-custom.ini
 fi
+unset PHP_INI_OVERRIDE
+
+# Remove ENV variables that are meant only for the SSH container
+
+unset SSH_PRIVATE_KEY
+unset IMPORT_GITLAB_PUB_KEYS
+unset IMPORT_GITHUB_PUB_KEYS
+unset IMPORT_PUB_KEYS
+unset SSH_CONFIG SSH_KNOWN_HOSTS
+
+# Remove ENV variables that are meant only for the web container
+
+unset HTTPD_EXTRA_CONF SSL_KEY SSL_CRT WEB_PORTS_HTTP WEB_PORTS_HTTPS
+

--- a/files/entrypoint.sh
+++ b/files/entrypoint.sh
@@ -30,6 +30,7 @@ if [ ! -z "${PHP_FPM_OVERRIDE}" ]; then
   echo "; Customizations from PHP_FPM_OVERRIDE:" >> $PHP_FPM_POOL_CONF
   echo "${PHP_FPM_OVERRIDE}" | sed -e 's/\\n/\n/g' >> $PHP_FPM_POOL_CONF
 fi
+unset PHP_FPM_OVERRIDE
 
 # Start the "real" entrypoint
 . /usr/local/bin/docker-php-entrypoint


### PR DESCRIPTION
Variables which are using in the bootstrapping and write some configuration files are removed before starting SSH server or the PHP-FPM process.

Neither in SSH nor in PHP-FPM we need to see these configuration variables (like `SSL_KEY` or `SSL_CRT` etc). 