### PR TITLE
Fix mysql client requiring ssl

### DIFF
--- a/files/ssh/entrypoint.sh
+++ b/files/ssh/entrypoint.sh
@@ -107,6 +107,8 @@ host=${DB_HOST}
 port=${DB_PORT}
 user=${DB_USER}
 password=${DB_PASS}
+skip-ssl=true
+
 EOF
 
   if ! ct --version | grep 2.5.4 >/dev/null


### PR DESCRIPTION
Newer mariadb clients have --ssl by default. Our server is not running on ssl.

See https://mariadb.com/docs/server/clients-and-utilities/mariadb-client/mariadb-command-line-client#-ssl