### PR TITLE
Allow setting php.ini and php-fpm pool setting via individual env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,24 @@ Application root is `/app`. Application runs as user `application` (uid=1000).
 | `PHP_FPM_OVERRIDE`                         | fpm      |             | Allow overriding php-fpm pool settings. The multiline content for php-fpm.conf here. Use "\n" for multiline i.e. in ECS                  |
 | `PHP_EXTENSIONS`                           | fpm, ssh | (all)       | Comma separated list of PHP extensions to enable (if this is not set, all are enabled).                                                  |
 | `PHP_DISABLE_EXTENSIONS`                   | fpm, ssh |             | Comma separated list of PHP extensions to disable (in case you keep all enabled, you can disable individual ones, i.e. igbinary).        |
+| `PHPINI__xxx__yyy`                         | fpm, ssh |             | Set php.ini setting `xxx.yyy` (always lower cased)                                                                                       |
+| `PHPFPM__xxx__yyy`                         | fpm      |             | Set php-fpm pool setting `xxx.yyy` (always lower cased)                                                                                  |
+
+The `PHPINI__...` and `PHPFPM__...` allow to set individual settings for `php.ini`
+and `php-fpm.conf` (pool settings) using individual environment variables. Just
+replace the `.` in the settings by `__`. Examples:
+
+Upper case allowed (will be lower-cased):
+```
+PHPINI__SESSION__SAVE_HANDLER=redis
+PHPINI__REDIS__SESSION__LOCKING_ENABLED=1
+```
+
+Or:
+```
+PHPFPM__request_terminate_timeout=30s
+PHPFPM__pm__max_children=15
+```
 
 ## Example usage
 

--- a/README.md
+++ b/README.md
@@ -176,14 +176,20 @@ replace the `.` in the settings by `__`. Examples:
 Upper case allowed (will be lower-cased):
 ```
 PHPINI__SESSION__SAVE_HANDLER=redis
+PHPINI__SESSION__SAVE_PATH='"tcp://redis:6379?persistent=1&weight=1&database=10&prefix=PHPSESSID:"'
 PHPINI__REDIS__SESSION__LOCKING_ENABLED=1
 ```
 
-Or:
+Or (lower case also fine):
 ```
 PHPFPM__request_terminate_timeout=30s
 PHPFPM__pm__max_children=15
 ```
+
+**Note**: make sure that potentially required double quotes `"` are part of the
+"string" that ends up in the ENV variable, so quote as necessary, because this
+string is copied "as is" to the ini files. See example above for the
+`PHPINI__SESSION__SAVE_PATH` - this would be the syntax for a `.env` file.
 
 ## Example usage
 

--- a/example-app/.env.example
+++ b/example-app/.env.example
@@ -47,10 +47,11 @@ pm.max_children = 5
 # PHP settings by env vars
 # -----------------------------------------
 
-# Example of setting php.ini settings
+# Example of setting php.ini settings, UPPER CASED
 PHPINI__SESSION__SAVE_HANDLER=redis
+PHPINI__SESSION__SAVE_PATH='"tcp://redis:6379?persistent=1&weight=1&database=10&prefix=PHPSESSID:"'
 PHPINI__REDIS__SESSION__LOCKING_ENABLED=1
 
-# Example of setting PHP-FPM settings
-PHPFPM__REQUEST_terminate_timeout=30s
+# Example of setting PHP-FPM settings, lower cased also possible
+PHPFPM__request_terminate_timeout=30s
 PHPFPM__pm__max_children=15

--- a/example-app/.env.example
+++ b/example-app/.env.example
@@ -42,3 +42,15 @@ slowlog = /tmp/slow.log
 request_slowlog_timeout = 3s
 pm.max_children = 5
 "
+
+# -----------------------------------------
+# PHP settings by env vars
+# -----------------------------------------
+
+# Example of setting php.ini settings
+PHPINI__SESSION__SAVE_HANDLER=redis
+PHPINI__REDIS__SESSION__LOCKING_ENABLED=1
+
+# Example of setting PHP-FPM settings
+PHPFPM__REQUEST_terminate_timeout=30s
+PHPFPM__pm__max_children=15

--- a/files/entrypoint-extras.sh
+++ b/files/entrypoint-extras.sh
@@ -86,6 +86,9 @@ if [ ! -z "${APPLICATION_UID}" ] || [ ! -z "${APPLICATION_GID}" ]; then
   test -d /home/application && find /home/application/ -mount -not -user application -exec chown application: {} \;
 fi
 
+# Start with a clean custom php.ini:
+rm -f "$CUSTOM_INI"
+
 if [ ! -z "${PHP_INI_OVERRIDE}" ]; then
   echo "${PHP_INI_OVERRIDE}" | sed -e 's/\\n/\n/g' > "$CUSTOM_INI"
 fi

--- a/files/entrypoint-extras.sh
+++ b/files/entrypoint-extras.sh
@@ -103,7 +103,8 @@ if env | grep -q '^PHPINI__'; then
     # Transform key: PHPINI__this__setting => this.setting
     key=${name#PHPINI__}
     key=$(printf '%s' "$key" | sed 's/__/./g')
-    key=${key,,}
+    # Lowercase in POSIX sh (dash/busybox) without bash-specific substitution
+    key=$(printf '%s' "$key" | tr '[:upper:]' '[:lower:]')
     # Append as "key = value" (value is written as-is; quote in ENV if needed)
     printf '* setting in php.ini: %s = %s\n' "$key" "$value"
     printf '%s = %s\n' "$key" "$value" >> "$CUSTOM_INI"

--- a/files/entrypoint-extras.sh
+++ b/files/entrypoint-extras.sh
@@ -103,10 +103,9 @@ if env | grep -q '^PHPINI__'; then
     # Transform key: PHPINI__this__setting => this.setting
     key=${name#PHPINI__}
     key=$(printf '%s' "$key" | sed 's/__/./g')
-    # Lowercase in POSIX sh (dash/busybox) without bash-specific substitution
     key=$(printf '%s' "$key" | tr '[:upper:]' '[:lower:]')
     # Append as "key = value" (value is written as-is; quote in ENV if needed)
-    printf '* setting in php.ini: %s = %s\n' "$key" "$value"
+    printf '* Setting in php.ini: %s = %s\n' "$key" "$value"
     printf '%s = %s\n' "$key" "$value" >> "$CUSTOM_INI"
     # Unset them, not relevant to the running containers
     unset "$name"

--- a/files/entrypoint-extras.sh
+++ b/files/entrypoint-extras.sh
@@ -7,6 +7,8 @@
 
 # Controls which extensions are enabled.
 
+CUSTOM_INI="/usr/local/etc/php/conf.d/zz-02-custom.ini"
+
 if [ ! -z "${PHP_EXTENSIONS}" ]; then
   # If PHP_EXTENSIONS is set: only enable the ones specified
 
@@ -85,9 +87,38 @@ if [ ! -z "${APPLICATION_UID}" ] || [ ! -z "${APPLICATION_GID}" ]; then
 fi
 
 if [ ! -z "${PHP_INI_OVERRIDE}" ]; then
-  echo "${PHP_INI_OVERRIDE}" | sed -e 's/\\n/\n/g' > /usr/local/etc/php/conf.d/zz-02-custom.ini
+  echo "${PHP_INI_OVERRIDE}" | sed -e 's/\\n/\n/g' > "$CUSTOM_INI"
 fi
 unset PHP_INI_OVERRIDE
+
+# Fill from ENV variables prefixed with PHPINI__
+# Example: PHPINI__session__save_handler=redis -> session.save_handler = redis
+#          PHPINI__redis__session__locking_enabled=1 -> redis.session.locking_enabled = 1
+if env | grep -q '^PHPINI__'; then
+  # Ensure the custom ini exists (and keep any content already written above)
+  touch "$CUSTOM_INI"
+  # Iterate over all matching env var names only
+  for name in $(printenv | awk -F= '/^PHPINI__/ {print $1}'); do
+    value=$(printenv "$name")
+    # Transform key: PHPINI__this__setting => this.setting
+    key=${name#PHPINI__}
+    key=$(printf '%s' "$key" | sed 's/__/./g')
+    key=${key,,}
+    # Append as "key = value" (value is written as-is; quote in ENV if needed)
+    printf '* setting in php.ini: %s = %s\n' "$key" "$value"
+    printf '%s = %s\n' "$key" "$value" >> "$CUSTOM_INI"
+    # Unset them, not relevant to the running containers
+    unset "$name"
+  done
+fi
+
+if [ -s "$CUSTOM_INI" ]
+then
+  echo "* Custom php.ini settings ($CUSTOM_INI)"
+  echo "- - - 8< - - -"
+  cat $CUSTOM_INI
+  echo "- - - 8< - - -"
+fi
 
 # Remove ENV variables that are meant only for the SSH container
 

--- a/files/entrypoint.sh
+++ b/files/entrypoint.sh
@@ -47,7 +47,7 @@ if env | grep -q '^PHPFPM__'; then
     # Transform key: PHPINI__this__setting => this.setting
     key=${name#PHPFPM__}
     key=$(printf '%s' "$key" | sed 's/__/./g')
-    key=${key,,}
+    key=$(printf '%s' "$key" | tr '[:upper:]' '[:lower:]')
     # Append as "key = value" (value is written as-is; quote in ENV if needed)
     printf '* PHP-FPM pool setting: %s = %s\n' "$key" "$value"
     printf '%s = %s\n' "$key" "$value" >> "$PHP_FPM_POOL_CONF"


### PR DESCRIPTION
The `PHPINI__...` and `PHPFPM__...` allow to set individual settings for `php.ini` and `php-fpm.conf` (pool settings) using individual environment variables. Just replace the `.` in the settings by `__`. Examples:

Upper case allowed (will be lower-cased):
```
PHPINI__SESSION__SAVE_HANDLER=redis
PHPINI__SESSION__SAVE_PATH='"tcp://redis:6379?persistent=1&weight=1&database=10&prefix=PHPSESSID:"'
PHPINI__REDIS__SESSION__LOCKING_ENABLED=1
```

Or:
```
PHPFPM__request_terminate_timeout=30s
PHPFPM__pm__max_children=15
```

Note: make sure the double quotes `"` are part of the "string" that ends up in the ENV variable, so quote as necessary, because this string is copied "as is" to the ini files). See example above for the `PHPINI__SESSION__SAVE_PATH` - this is the syntax for a `.env` file.
